### PR TITLE
This adds synthesizer context class and fix related calls in mcmc sampler

### DIFF
--- a/xdsl_smt/cli/syn_test.py
+++ b/xdsl_smt/cli/syn_test.py
@@ -4,6 +4,7 @@ from xdsl.context import MLContext
 from xdsl.parser import Parser
 
 from xdsl_smt.utils.mcmc_sampler import MCMCSampler
+from xdsl_smt.utils.synthesizer_context import SynthesizerContext
 from ..dialects.smt_dialect import (
     SMTDialect,
 )
@@ -66,8 +67,9 @@ def main() -> None:
 
     random.seed(47)
     func = module.ops.first
+    context = SynthesizerContext()
 
-    mcmc_sampler = MCMCSampler(func, 4)
+    mcmc_sampler = MCMCSampler(func, 4, context)
     print(mcmc_sampler.get_current())
     for i in range(0):
         _: float = mcmc_sampler.sample_next()

--- a/xdsl_smt/cli/synth_transfer.py
+++ b/xdsl_smt/cli/synth_transfer.py
@@ -70,6 +70,7 @@ import sys as sys
 
 from ..utils.cost_model import compute_cost, compute_accept_rate
 from ..utils.mcmc_sampler import MCMCSampler
+from ..utils.synthesizer_context import SynthesizerContext
 from ..utils.transfer_function_check_util import (
     forward_soundness_check,
     backward_soundness_check,
@@ -438,7 +439,8 @@ def main() -> None:
     possible_solution: set[str] = set()
 
     random.seed(17)
-
+    context = SynthesizerContext()
+    context.set_cmp_flags([0, 6, 7])
     for func in module.ops:
         if isinstance(func, FuncOp) and is_transfer_function(func):
             concrete_func_name = ""
@@ -449,7 +451,7 @@ def main() -> None:
                 concrete_func_name = applied_to.data[0].data
             concrete_func = get_concrete_function(concrete_func_name, SYNTH_WIDTH, None)
             func_name = func.sym_name.data
-            mcmc_sampler = MCMCSampler(func, 8)
+            mcmc_sampler = MCMCSampler(func, 8, context)
 
             current_cost = 20
             for i in range(10000):

--- a/xdsl_smt/utils/mcmc_sampler.py
+++ b/xdsl_smt/utils/mcmc_sampler.py
@@ -21,7 +21,7 @@ from xdsl.dialects.builtin import (
     i1,
 )
 from xdsl.dialects.func import FuncOp, Return
-from xdsl.ir import Operation, OpResult
+from xdsl.ir import Operation, OpResult, SSAValue
 import sys as sys
 import random
 
@@ -72,11 +72,11 @@ class MCMCSampler:
 
     def get_valid_bool_operands(
         self, ops: list[Operation], x: int
-    ) -> tuple[list[OpResult], int]:
+    ) -> tuple[list[SSAValue], int]:
         """
         Get operations that before ops[x] so that can serve as operands
         """
-        bool_ops = [
+        bool_ops: list[SSAValue] = [
             result for op in ops[:x] for result in op.results if result.type == i1
         ]
         bool_count = len(bool_ops)
@@ -85,11 +85,11 @@ class MCMCSampler:
 
     def get_valid_int_operands(
         self, ops: list[Operation], x: int
-    ) -> tuple[list[OpResult], int]:
+    ) -> tuple[list[SSAValue], int]:
         """
         Get operations that before ops[x] so that can serve as operands
         """
-        int_ops = [
+        int_ops: list[SSAValue] = [
             result
             for op in ops[:x]
             for result in op.results

--- a/xdsl_smt/utils/synthesizer_context.py
+++ b/xdsl_smt/utils/synthesizer_context.py
@@ -174,9 +174,13 @@ class SynthesizerContext:
             lambda op_ty: op_ty != type(except_op)
         )
         if result_type == CmpOp:
-            return CmpOp(int_vals[0], int_vals[1], random.choice(self.cmp_flags))
+            return CmpOp(
+                random.choice(int_vals),
+                random.choice(int_vals),
+                random.choice(self.cmp_flags),
+            )
         assert result_type is not None
-        return result_type(i1_vals[0], i1_vals[1])
+        return result_type(random.choice(i1_vals), random.choice(i1_vals))
 
     def get_random_int_op_except(
         self, int_vals: list[SSAValue], i1_vals: list[SSAValue], except_op: Operation
@@ -185,8 +189,10 @@ class SynthesizerContext:
             lambda op_ty: op_ty != type(except_op)
         )
         if result_type == SelectOp:
-            return SelectOp(i1_vals[0], int_vals[0], int_vals[1])
+            return SelectOp(
+                random.choice(i1_vals), random.choice(int_vals), random.choice(int_vals)
+            )
         elif result_type == NegOp:
-            return NegOp(int_vals[0])
+            return NegOp(random.choice(int_vals))
         assert result_type is not None
-        return result_type(int_vals[0], int_vals[1])
+        return result_type(random.choice(int_vals), random.choice(int_vals))

--- a/xdsl_smt/utils/synthesizer_context.py
+++ b/xdsl_smt/utils/synthesizer_context.py
@@ -1,0 +1,151 @@
+from ..dialects.transfer import (
+    NegOp,
+    CmpOp,
+    AndOp,
+    OrOp,
+    XorOp,
+    AddOp,
+    SubOp,
+    CountLOneOp,
+    CountLZeroOp,
+    CountROneOp,
+    CountRZeroOp,
+    # SetHighBitsOp,
+    # SetLowBitsOp,
+    # GetLowBitsOp,
+    # GetBitWidthOp,
+    # UMulOverflowOp,
+    # SMinOp,
+    # SMaxOp,
+    # UMinOp,
+    # UMaxOp,
+    ShlOp,
+    LShrOp,
+    SelectOp,
+)
+from xdsl.pattern_rewriter import *
+from typing import TypeVar, Generic
+from xdsl.ir import Operation
+import xdsl.dialects.arith as arith
+import random
+
+T = TypeVar("T")
+
+
+class Collection(Generic[T]):
+    """
+    This class implements a data structure called Collection.
+    It supports O(1) insert, delete and retrieve a random element.
+    """
+
+    lst: list[T]
+    lst_len: int
+    ele_to_index: dict[T, int]
+
+    def __init__(self, lst: list[T]):
+        self.lst = []
+        self.ele_to_index = {}
+        self.lst_len = 0
+        for i, ele in enumerate(lst):
+            self.lst.append(ele)
+            self.ele_to_index[ele] = i
+            self.lst_len += 1
+
+    def add(self, ele: T):
+        self.lst.append(ele)
+        self.lst_len += 1
+        self.ele_to_index[ele] = self.lst_len
+
+    def remove(self, ele: T):
+        if ele in self.ele_to_index:
+            idx = self.ele_to_index[ele]
+            self.lst[idx] = self.lst[-1]
+            self.lst.pop()
+            self.lst_len -= 1
+            del self.ele_to_index[ele]
+
+    def size(self):
+        return self.lst_len
+
+    def get_random_element(self) -> T | None:
+        if self.lst_len != 0:
+            return random.choice(self.lst)
+        return None
+
+    def get_all_elements(self):
+        return tuple(self.lst)
+
+    def get_random_element_if(self, predicate: Callable[[T], bool]) -> T | None:
+        idx = random.randint(0, self.lst_len - 1)
+        for i in range(self.lst_len):
+            if predicate(self.lst[idx]):
+                return self.lst[idx]
+            idx += 1
+            idx %= self.lst_len
+        return None
+
+
+basic_int_ops = (NegOp, AndOp, OrOp, XorOp, AddOp, SubOp, SelectOp)
+full_int_ops = (
+    NegOp,
+    AndOp,
+    OrOp,
+    XorOp,
+    AddOp,
+    SubOp,
+    SelectOp,
+    LShrOp,
+    ShlOp,
+    CountLOneOp,
+    CountLZeroOp,
+    CountROneOp,
+    CountRZeroOp,
+)
+basic_i1_ops = (arith.AndI, arith.OrI, arith.XOrI, CmpOp)
+
+
+class SynthesizerContext:
+    cmp_flags: list[int]
+    i1_ops: tuple
+    int_ops: tuple
+
+    def __init__(self):
+        self.cmp_flags = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        self.i1_ops = basic_i1_ops
+        self.int_ops = basic_int_ops
+
+    def use_basic_int_ops(self):
+        self.int_ops = basic_int_ops
+
+    def use_full_int_ops(self):
+        self.int_ops = full_int_ops
+
+    def get_available_i1_ops(self):
+        return self.i1_ops
+
+    def get_available_int_ops(self):
+        return self.int_ops
+
+    def set_cmp_flags(self, cmp_flags: list[int]):
+        assert len(cmp_flags) != 0
+        for flag in cmp_flags:
+            assert 0 <= flag and flag <= 9
+        self.cmp_flags = cmp_flags
+
+    def get_random_i1_op(
+        self, int_vals: list[SSAValue], i1_vals: list[SSAValue]
+    ) -> Operation:
+        result_type = random.choice(self.i1_ops)
+        if result_type == CmpOp:
+            return CmpOp(int_vals[0], int_vals[1], random.choice(self.cmp_flags))
+        return result_type(i1_vals[0], i1_vals[1])
+
+    def get_random_int_op(
+        self, int_vals: list[SSAValue], i1_vals: list[SSAValue]
+    ) -> Operation:
+        result_type = random.choice(self.int_ops)
+        if result_type == SelectOp:
+            return SelectOp(i1_vals[0], int_vals[0], int_vals[1])
+        elif result_type == NegOp:
+            return NegOp(int_vals[0])
+        return result_type(int_vals[0], int_vals[1])

--- a/xdsl_smt/utils/synthesizer_context.py
+++ b/xdsl_smt/utils/synthesizer_context.py
@@ -72,8 +72,8 @@ class Collection(Generic[T]):
             return random.choice(self.lst)
         return None
 
-    def get_all_elements(self):
-        return tuple(self.lst)
+    def get_all_elements(self) -> tuple[T]:
+        return tuple(*self.lst)
 
     def get_random_element_if(self, predicate: Callable[[T], bool]) -> T | None:
         idx = random.randint(0, self.lst_len - 1)
@@ -85,29 +85,44 @@ class Collection(Generic[T]):
         return None
 
 
-basic_int_ops = (NegOp, AndOp, OrOp, XorOp, AddOp, SubOp, SelectOp)
-full_int_ops = (
-    NegOp,
-    AndOp,
-    OrOp,
-    XorOp,
-    AddOp,
-    SubOp,
-    SelectOp,
-    LShrOp,
-    ShlOp,
-    CountLOneOp,
-    CountLZeroOp,
-    CountROneOp,
-    CountRZeroOp,
+basic_int_ops: Collection[type[Operation]] = Collection(
+    [
+        NegOp,
+        AndOp,
+        OrOp,
+        XorOp,
+        AddOp,
+        SubOp,
+        SelectOp,
+    ]
 )
-basic_i1_ops = (arith.AndI, arith.OrI, arith.XOrI, CmpOp)
+
+full_int_ops: Collection[type[Operation]] = Collection(
+    [
+        NegOp,
+        AndOp,
+        OrOp,
+        XorOp,
+        AddOp,
+        SubOp,
+        SelectOp,
+        LShrOp,
+        ShlOp,
+        CountLOneOp,
+        CountLZeroOp,
+        CountROneOp,
+        CountRZeroOp,
+    ]
+)
+basic_i1_ops: Collection[type[Operation]] = Collection(
+    [arith.AndI, arith.OrI, arith.XOrI, CmpOp]
+)
 
 
 class SynthesizerContext:
     cmp_flags: list[int]
-    i1_ops: tuple
-    int_ops: tuple
+    i1_ops: Collection[type[Operation]]
+    int_ops: Collection[type[Operation]]
 
     def __init__(self):
         self.cmp_flags = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -120,11 +135,11 @@ class SynthesizerContext:
     def use_full_int_ops(self):
         self.int_ops = full_int_ops
 
-    def get_available_i1_ops(self):
-        return self.i1_ops
+    def get_available_i1_ops(self) -> tuple[type[Operation]]:
+        return self.i1_ops.get_all_elements()
 
-    def get_available_int_ops(self):
-        return self.int_ops
+    def get_available_int_ops(self) -> tuple[type[Operation]]:
+        return self.int_ops.get_all_elements()
 
     def set_cmp_flags(self, cmp_flags: list[int]):
         assert len(cmp_flags) != 0
@@ -135,17 +150,43 @@ class SynthesizerContext:
     def get_random_i1_op(
         self, int_vals: list[SSAValue], i1_vals: list[SSAValue]
     ) -> Operation:
-        result_type = random.choice(self.i1_ops)
+        result_type = self.i1_ops.get_random_element()
         if result_type == CmpOp:
             return CmpOp(int_vals[0], int_vals[1], random.choice(self.cmp_flags))
+        assert result_type is not None
         return result_type(i1_vals[0], i1_vals[1])
 
     def get_random_int_op(
         self, int_vals: list[SSAValue], i1_vals: list[SSAValue]
     ) -> Operation:
-        result_type = random.choice(self.int_ops)
+        result_type = self.int_ops.get_random_element()
         if result_type == SelectOp:
             return SelectOp(i1_vals[0], int_vals[0], int_vals[1])
         elif result_type == NegOp:
             return NegOp(int_vals[0])
+        assert result_type is not None
+        return result_type(int_vals[0], int_vals[1])
+
+    def get_random_i1_op_except(
+        self, int_vals: list[SSAValue], i1_vals: list[SSAValue], except_op: Operation
+    ) -> Operation:
+        result_type = self.i1_ops.get_random_element_if(
+            lambda op_ty: op_ty != type(except_op)
+        )
+        if result_type == CmpOp:
+            return CmpOp(int_vals[0], int_vals[1], random.choice(self.cmp_flags))
+        assert result_type is not None
+        return result_type(i1_vals[0], i1_vals[1])
+
+    def get_random_int_op_except(
+        self, int_vals: list[SSAValue], i1_vals: list[SSAValue], except_op: Operation
+    ) -> Operation:
+        result_type = self.int_ops.get_random_element_if(
+            lambda op_ty: op_ty != type(except_op)
+        )
+        if result_type == SelectOp:
+            return SelectOp(i1_vals[0], int_vals[0], int_vals[1])
+        elif result_type == NegOp:
+            return NegOp(int_vals[0])
+        assert result_type is not None
         return result_type(int_vals[0], int_vals[1])


### PR DESCRIPTION
This PR includes following changes:
1. A synthesizer context used for getting random operation constructions
2. Replace operation constructions in MCMCSampler with calls to synthesizer context
3. Remove static attributes for certain operations in MCMCSampler