### PR TITLE
Update eval engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
 
 [tool.setuptools]
 platforms = ["Linux", "Mac OS-X", "Unix"]
+packages = ["xdsl_smt"]
 zip-safe = false
 
 [tool.setuptools.package-data]
@@ -34,6 +35,7 @@ cpp-translate = "xdsl_smt.cli.cpp_translate:main"
 superoptimize = "xdsl_smt.cli.superoptimize:main"
 syn-test = "xdsl_smt.cli.syn_test:main"
 synth-transfer = "xdsl_smt.cli.synth_transfer:main"
+eval-test= "xdsl_smt.cli.eval_test:main"
 
 [build-system]
 requires = ["setuptools>=61", "wheel"]
@@ -52,5 +54,6 @@ ignore = [
   "xdsl_smt/passes/transfer_lower.py",
   "xdsl_smt/cli/xdsl_translate.py",
   "xdsl_smt/cli/verifier.py",
-  "tests"
+  "tests",
+  "outputs"
 ]

--- a/tests/synth/knownBitsUrem.mlir
+++ b/tests/synth/knownBitsUrem.mlir
@@ -1,0 +1,59 @@
+"builtin.module"() ({
+"func.func"() ({
+  ^bb0(%arg0: !transfer.integer, %arg1: !transfer.integer):
+    %const0 = "transfer.constant"(%arg1) {value=0:index}:(!transfer.integer)->!transfer.integer
+    %arg1_eq_0 = "transfer.cmp"(%const0, %arg1) {predicate=0:i64}: (!transfer.integer, !transfer.integer) -> i1
+    %const1 = "arith.constant"() {value=1:i1}: () -> i1
+    %check = "arith.xori"(%arg1_eq_0, %const1) : (i1, i1) -> i1
+    "func.return"(%check) : (i1) -> ()
+  }) {function_type = (!transfer.integer, !transfer.integer) -> i1, sym_name = "op_constraint"} : () -> ()
+
+ "func.func"() ({
+  ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
+    %arg0_0 = "transfer.get"(%arg0) {index=0:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %arg0_1 = "transfer.get"(%arg0) {index=1:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %andi = "transfer.and"(%arg0_0, %arg0_1) : (!transfer.integer,!transfer.integer) -> !transfer.integer
+    %const0 = "transfer.constant"(%arg0_0){value=0:index} : (!transfer.integer) -> !transfer.integer
+    %result = "transfer.cmp"(%andi, %const0){predicate=0:i64}:(!transfer.integer,!transfer.integer)->i1
+    "func.return"(%result) : (i1) -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> i1, sym_name = "getConstraint"} : () -> ()
+  "func.func"() ({
+  ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %inst: !transfer.integer):
+    %arg0_0 = "transfer.get"(%arg0) {index=0:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %arg0_1 = "transfer.get"(%arg0) {index=1:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %neg_inst = "transfer.neg"(%inst) : (!transfer.integer) -> !transfer.integer
+    %or1 = "transfer.or"(%neg_inst,%arg0_0): (!transfer.integer,!transfer.integer)->!transfer.integer
+    %or2 = "transfer.or"(%inst,%arg0_1): (!transfer.integer,!transfer.integer)->!transfer.integer
+    %cmp1="transfer.cmp"(%or1,%neg_inst){predicate=0:i64}:(!transfer.integer,!transfer.integer)->i1
+    %cmp2="transfer.cmp"(%or2,%inst){predicate=0:i64}:(!transfer.integer,!transfer.integer)->i1
+    %result="arith.andi"(%cmp1,%cmp2):(i1,i1)->i1
+    "func.return"(%result) : (i1) -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>, !transfer.integer) -> i1, sym_name = "getInstanceConstraint"} : () -> ()
+
+"func.func"() ({
+  ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
+    %arg00 = "transfer.get"(%arg0) {index=0:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %arg01 = "transfer.get"(%arg0) {index=1:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %andi = "transfer.and"(%arg00, %arg01) : (!transfer.integer,!transfer.integer) -> !transfer.integer
+    %const0 = "transfer.constant"(%arg00){value=0:index} : (!transfer.integer) -> !transfer.integer
+    %result = "transfer.cmp"(%andi, %const0){predicate=0:i64}:(!transfer.integer,!transfer.integer)->i1
+    "func.return"(%result) : (i1) -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> i1, sym_name = "getConstraint"} : () -> ()
+  "func.func"() ({
+  ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %inst: !transfer.integer):
+    %arg00 = "transfer.get"(%arg0) {index=0:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %arg01 = "transfer.get"(%arg0) {index=1:index}: (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.integer
+    %neg_inst = "transfer.neg"(%inst) : (!transfer.integer) -> !transfer.integer
+    %or1 = "transfer.or"(%neg_inst,%arg00): (!transfer.integer,!transfer.integer)->!transfer.integer
+    %or2 = "transfer.or"(%inst,%arg01): (!transfer.integer,!transfer.integer)->!transfer.integer
+    %cmp1="transfer.cmp"(%or1,%neg_inst){predicate=0:i64}:(!transfer.integer,!transfer.integer)->i1
+    %cmp2="transfer.cmp"(%or2,%inst){predicate=0:i64}:(!transfer.integer,!transfer.integer)->i1
+    %result="arith.andi"(%cmp1,%cmp2):(i1,i1)->i1
+    "func.return"(%result) : (i1) -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>, !transfer.integer) -> i1, sym_name = "getInstanceConstraint"} : () -> ()
+  "func.func"() ({
+  ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %arg1: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
+    "func.return"(%arg0) : (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "ANDImpl", applied_to=["comb.shl"], CPPCLASS=["circt::comb::AndOp"], is_forward=true} : () -> ()
+
+}) {"builtin.NEED_VERIFY"=[["MUL","MULImpl"],["OR","ORImpl"],["AND","ANDImpl"],["XOR","XORImpl"],["ADD","ADDImpl"],["SUB","SUBImpl"],["MUX","MUXImpl"],["SHL","SHLImpl"]]}: () -> ()

--- a/xdsl_smt/cli/synth_transfer.py
+++ b/xdsl_smt/cli/synth_transfer.py
@@ -463,10 +463,10 @@ def main() -> None:
     if random_number_file is not None:
         random.read_from_file(random_number_file)
 
-    PROGRAM_LENGTH = 16
-    NUM_PROGRAMS = 2
+    PROGRAM_LENGTH = 32
+    NUM_PROGRAMS = 100
     INIT_COST = 20
-    TOTAL_ROUNDS = 1
+    TOTAL_ROUNDS = 1000
 
     # sound_data: list[list[float]] = [[] for _ in range(NUM_PROGRAMS)]
     # precision_data: list[list[float]] = [[] for _ in range(NUM_PROGRAMS)]
@@ -535,6 +535,9 @@ def main() -> None:
                     + op_constraint_func,
                 )
 
+                soundness_percent = [1 - (a / b) for a, b in zip(num_unsound, num_cases)]
+                precision_percent = [a / b for a, b in zip(num_exact, num_cases)]
+
                 for i in range(NUM_PROGRAMS):
                     proposed_cost = compute_cost(
                         soundness_percent[i], precision_percent[i]
@@ -601,3 +604,6 @@ def main() -> None:
                         """
     for item in possible_solution:
         print(item)
+
+
+

--- a/xdsl_smt/cli/synth_transfer.py
+++ b/xdsl_smt/cli/synth_transfer.py
@@ -391,11 +391,20 @@ def print_to_cpp(func: FuncOp) -> str:
     return sio.getvalue()
 
 
+def get_default_op_constraint():
+    return """
+    int op_constraint(APInt arg0,APInt arg1){
+	return true;
+    }
+    """
+
+
 SYNTH_WIDTH = 8
 TEST_SET_SIZE = 1000
 CONCRETE_VAL_PER_TEST_CASE = 10
 INSTANCE_CONSTRAINT = "getInstanceConstraint"
 DOMAIN_CONSTRAINT = "getConstraint"
+OP_CONSTRAINT = "op_constraint"
 TMP_MODULE: list[ModuleOp] = []
 ctx: MLContext
 
@@ -455,9 +464,9 @@ def main() -> None:
         random.read_from_file(random_number_file)
 
     PROGRAM_LENGTH = 16
-    NUM_PROGRAMS = 50
+    NUM_PROGRAMS = 2
     INIT_COST = 20
-    TOTAL_ROUNDS = 500
+    TOTAL_ROUNDS = 1
 
     # sound_data: list[list[float]] = [[] for _ in range(NUM_PROGRAMS)]
     # precision_data: list[list[float]] = [[] for _ in range(NUM_PROGRAMS)]
@@ -465,6 +474,20 @@ def main() -> None:
 
     context = SynthesizerContext(random)
     context.set_cmp_flags([0, 6, 7])
+
+    domain_constraint_func = None
+    instance_constraint_func = None
+    op_constraint_func = get_default_op_constraint()
+    # Handle helper funcitons
+    for func in module.ops:
+        if isinstance(func, FuncOp):
+            func_name = func.sym_name.data
+            if func_name == DOMAIN_CONSTRAINT:
+                domain_constraint_func = print_to_cpp(func)
+            elif func_name == INSTANCE_CONSTRAINT:
+                instance_constraint_func = print_to_cpp(func)
+            elif func_name == OP_CONSTRAINT:
+                op_constraint_func = print_to_cpp(func)
 
     for func in module.ops:
         if isinstance(func, FuncOp) and is_transfer_function(func):
@@ -475,6 +498,7 @@ def main() -> None:
                 )
                 concrete_func_name = applied_to.data[0].data
             concrete_func = get_concrete_function(concrete_func_name, SYNTH_WIDTH, None)
+            crt_func = print_concrete_function_to_cpp(concrete_func)
             func_name = func.sym_name.data
             mcmc_samplers: list[MCMCSampler] = []
 
@@ -499,9 +523,16 @@ def main() -> None:
                     cpp_code = print_to_cpp(func_to_eval)
                     cpp_codes.append(cpp_code)
 
-                crt_func = print_concrete_function_to_cpp(concrete_func)
-                soundness_percent, precision_percent = eval_transfer_func(
-                    [func_name] * NUM_PROGRAMS, cpp_codes, crt_func
+                num_unsound, num_imprecise, num_exact, num_cases = eval_transfer_func(
+                    [func_name] * NUM_PROGRAMS,
+                    cpp_codes,
+                    crt_func
+                    + "\n"
+                    + instance_constraint_func
+                    + "\n"
+                    + domain_constraint_func
+                    + "\n"
+                    + op_constraint_func,
                 )
 
                 for i in range(NUM_PROGRAMS):

--- a/xdsl_smt/eval_engine/eval.py
+++ b/xdsl_smt/eval_engine/eval.py
@@ -107,7 +107,7 @@ def eval_transfer_func(
     xfer_names: list[str],
     xfer_srcs: list[str],
     concrete_op_expr: str,
-) -> tuple[list[float], list[float]]:
+) -> tuple[list[int], list[int], list[int], list[int]]:
     transfer_func_header = make_xfer_header(concrete_op_expr)
 
     xfer_srcs = [
@@ -135,7 +135,7 @@ def eval_transfer_func(
     run(get_build_cmd(), stdout=PIPE)
     eval_output = run(["./EvalEngine"], stdout=PIPE)
 
-    def get_floats(s: str) -> list[float]:
+    def get_floats(s: str) -> list[int]:
         return eval(s)
 
     os.chdir(cur_dir)
@@ -143,8 +143,10 @@ def eval_transfer_func(
     eval_output_lines = eval_output.stdout.decode("utf-8").split("\n")
     sounds = get_floats(eval_output_lines[1])
     precs = get_floats(eval_output_lines[3])
+    exact = get_floats(eval_output_lines[3])
+    num_cases = get_floats(eval_output_lines[3])
 
-    return sounds, precs
+    return sounds, precs, exact, num_cases
 
 
 '''

--- a/xdsl_smt/eval_engine/eval.py
+++ b/xdsl_smt/eval_engine/eval.py
@@ -143,8 +143,8 @@ def eval_transfer_func(
     eval_output_lines = eval_output.stdout.decode("utf-8").split("\n")
     sounds = get_floats(eval_output_lines[1])
     precs = get_floats(eval_output_lines[3])
-    exact = get_floats(eval_output_lines[3])
-    num_cases = get_floats(eval_output_lines[3])
+    exact = get_floats(eval_output_lines[5])
+    num_cases = get_floats(eval_output_lines[7])
 
     return sounds, precs, exact, num_cases
 

--- a/xdsl_smt/eval_engine/src/main.cpp
+++ b/xdsl_smt/eval_engine/src/main.cpp
@@ -229,7 +229,7 @@ int main() {
           all_cases[i][0]+=1;
           all_cases[i][2]+=1;
         }else{
-          auto num_non_precision = compare_abstract(synth_kbs[i], best_abstract_res, isSound);
+          auto num_non_precision = compare_abstract(synth_kbs[i], best_abstract_res, isUnsound);
           if(isUnsound){
             all_cases[i][0]+=1;
           }

--- a/xdsl_smt/eval_engine/src/main.cpp
+++ b/xdsl_smt/eval_engine/src/main.cpp
@@ -88,6 +88,27 @@ llvm::KnownBits const to_abstract(const std::vector<uint8_t> &conc_vals,
   return ret;
 }
 
+llvm::KnownBits to_best_abstract(const llvm::KnownBits lhs, const llvm::KnownBits rhs,uint8_t (*op)(const uint8_t,
+                                                          const uint8_t), uint8_t bitwidth){
+  bool hasInit=false;
+  llvm::KnownBits result(bitwidth);
+  uint8_t mask = 0b00001111;
+  for (auto lhs_val : to_concrete(lhs)) {
+    for (auto rhs_val : to_concrete(rhs)){
+      if(op_constraint(APInt(bitwidth, lhs_val), APInt(bitwidth, rhs_val))){
+        auto crt_res = llvm::KnownBits::makeConstant(llvm::APInt(bitwidth, op(lhs_val, rhs_val) & mask));
+        if(!hasInit){
+          result=crt_res;
+          hasInit=true;
+        }else{
+          result = result.intersectWith(crt_res);
+        }
+      }
+    }
+  }
+  return result;
+}
+
 // TODO be able to return generic std container
 // TODO have some automated check for UB?
 // TODO auto vary bitmask based on width and spec consideration for signed ints
@@ -108,6 +129,28 @@ std::vector<uint8_t> const concrete_op_enum(const std::vector<uint8_t> &lhss,
   ret.erase(unique(ret.begin(), ret.end()), ret.end());
 
   return ret;
+}
+
+unsigned int compare_abstract(llvm::KnownBits abs_res, llvm::KnownBits best_abs_res, bool& isUnsound){
+  const llvm::APInt min = llvm::APInt::getZero(abs_res.Zero.getBitWidth());
+  const llvm::APInt max = llvm::APInt::getMaxValue(abs_res.Zero.getBitWidth());
+
+  unsigned result =0;
+
+  for (auto i = min;; ++i) {
+    bool in_abs_res = !abs_res.Zero.intersects(i) && !abs_res.One.intersects(~i);
+    bool in_best_abs_res = !best_abs_res.Zero.intersects(i) && !best_abs_res.One.intersects(~i);
+    if(in_best_abs_res&&!in_abs_res){
+      //unsound
+      isUnsound=true;
+    }else if(in_abs_res&&!in_best_abs_res){
+      ++result;
+    }
+    if (i == max)
+      break;
+  }
+
+  return result;
 }
 
 // TODO make case enum
@@ -154,10 +197,12 @@ int main() {
   for (auto lhs : enum_abst_vals(bitwidth)) {
     for (auto rhs : enum_abst_vals(bitwidth)) {
 
-      auto brute_vals =
-          concrete_op_enum(to_concrete(lhs), to_concrete(rhs), concrete_op_wrapper);
+      //auto brute_vals =
+      //    concrete_op_enum(to_concrete(lhs), to_concrete(rhs), concrete_op_wrapper);
+      auto best_abstract_res = to_best_abstract(lhs, rhs, concrete_op_wrapper, bitwidth);
 
       std::vector<llvm::KnownBits> synth_kbs(synth_function_wrapper(lhs, rhs));
+      /*
       std::vector<std::vector<uint8_t>> all_synth_xfer_vals(synth_kbs.size());
 
       std::transform(synth_kbs.begin(), synth_kbs.end(),
@@ -169,29 +214,34 @@ int main() {
                      [&brute_vals](std::vector<uint8_t> &transfer_vals) {
                        return compare(transfer_vals, brute_vals);
                      });
+      */
 
       if (all_cases.size() == 0) {
-        all_cases.resize(all_results.size());
+        all_cases.resize(synth_kbs.size());
         std::fill(all_cases.begin(), all_cases.end(),
                   std::vector<unsigned int>{0, 0, 0, 0});
       }
 
-      for (int i = 0; i < all_results.size(); ++i) {
-        all_cases[i][all_results[i]]++;
+      for (int i = 0; i < synth_kbs.size(); ++i) {
+        //sound non_precision exact num_cases
+        bool isUnsound=false;
+        if(synth_kbs[i] == best_abstract_res){
+          all_cases[i][0]+=1;
+          all_cases[i][2]+=1;
+        }else{
+          auto num_non_precision = compare_abstract(synth_kbs[i], best_abstract_res, isSound);
+          if(isUnsound){
+            all_cases[i][0]+=1;
+          }
+          all_cases[i][1]+=num_non_precision;
+        }
       }
 
       total_abst_combos++;
     }
   }
-
-  std::vector<double> p_sound;
-  std::vector<double> p_precise;
-
-  for (int i = 0; i < all_cases.size(); ++i) {
-    p_sound.push_back((double)(all_cases[i][3] + all_cases[i][2]) /
-                      (double)total_abst_combos);
-    p_precise.push_back((double)(all_cases[i][3] + all_cases[i][1]) /
-                        (double)total_abst_combos);
+  for(auto& res:all_cases){
+    res[3]=total_abst_combos;
   }
 
   // printf("Not sound or precise: %i\n", cases[0]);
@@ -202,21 +252,29 @@ int main() {
 
   puts("sound:");
   printf("[");
-  for (int i = 0; i < p_sound.size(); ++i) {
-    if (i == p_sound.size() - 1)
-      printf("%f", p_sound[i]);
-    else
-      printf("%f, ", p_sound[i]);
+  for (int i = 0; i < all_cases.size(); ++i) {
+    printf("%d, ", all_cases[i][0]);
   }
   printf("]\n");
 
   puts("precise:");
   printf("[");
-  for (int i = 0; i < p_precise.size(); ++i) {
-    if (i == p_precise.size() - 1)
-      printf("%f", p_precise[i]);
-    else
-      printf("%f, ", p_precise[i]);
+  for (int i = 0; i < all_cases.size(); ++i) {
+    printf("%d, ", all_cases[i][1]);
+  }
+  printf("]\n");
+
+  puts("exact:");
+  printf("[");
+  for (int i = 0; i < all_cases.size(); ++i) {
+    printf("%d, ", all_cases[i][2]);
+  }
+  printf("]\n");
+
+  puts("num_cases:");
+  printf("[");
+  for (int i = 0; i < all_cases.size(); ++i) {
+    printf("%d, ", all_cases[i][3]);
   }
   printf("]\n");
 

--- a/xdsl_smt/eval_engine/src/main.cpp
+++ b/xdsl_smt/eval_engine/src/main.cpp
@@ -226,7 +226,6 @@ int main() {
         //sound non_precision exact num_cases
         bool isUnsound=false;
         if(synth_kbs[i] == best_abstract_res){
-          all_cases[i][0]+=1;
           all_cases[i][2]+=1;
         }else{
           auto num_non_precision = compare_abstract(synth_kbs[i], best_abstract_res, isUnsound);

--- a/xdsl_smt/utils/cost_model.py
+++ b/xdsl_smt/utils/cost_model.py
@@ -6,11 +6,14 @@ def compute_cost(soundness: float, precision: float) -> float:
     #     return 1 - precision
     # else:
     #     return 2 - soundness
-    return 16 * (1 - soundness) ** 2 + 1 - precision
+    a: float = 1
+    b: float = 4
+    return (a * (1 - soundness) + b * (1 - precision)) / (a + b)
 
 
 def decide(p: float, beta: float, current_cost: float, proposed_cost: float) -> bool:
     # return math.exp(-16 * (proposed_cost - current_cost))
-    # return 1 if proposed_cost <= current_cost else 0
+
+    # return True
 
     return beta * (current_cost - proposed_cost) > math.log(p)


### PR DESCRIPTION
This PR includes following changes:
1. Allow an op_constraint to skip certain concrete values when evaluation
2. Returns four value lists (num_unsound, num_imprecise, num_exact, num_cases) instead of two
3. Fixed a bug in abstract calculation.