### PR TITLE
Exit program when there is a unsound bug in Eval Engine

### DIFF
--- a/xdsl_smt/utils/synthesizer_utils/log_utils.py
+++ b/xdsl_smt/utils/synthesizer_utils/log_utils.py
@@ -1,4 +1,5 @@
 import logging
+from logging import critical
 from typing import List
 
 from xdsl.dialects.func import FuncOp
@@ -23,6 +24,14 @@ def setup_loggers(output_dir: str, verbose: int):
         debug_handler.setLevel(logging.DEBUG)
         debug_handler.setFormatter(formatter)
         logger.addHandler(debug_handler)
+
+    critical_handler = logging.FileHandler(output_dir + "/critial.cpp", mode="w")
+    critical_handler.setLevel(logging.CRITICAL)
+    logger.addHandler(critical_handler)
+
+    error_handler = logging.FileHandler(output_dir + "/error.mlir", mode="w")
+    error_handler.setLevel(logging.ERROR)
+    logger.addHandler(error_handler)
 
     return logger
 

--- a/xdsl_smt/utils/synthesizer_utils/solution_set.py
+++ b/xdsl_smt/utils/synthesizer_utils/solution_set.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import io
 from typing import Callable
 
 from xdsl.context import MLContext
@@ -364,6 +366,20 @@ class UnsizedSolutionSet(SolutionSet):
             )
             if unsound_bit != 0:
                 self.logger.info(f"Skip a unsound function at bit width {unsound_bit}")
+                if unsound_bit == 4:
+                    func_str, helper_str = candidates[index].get_function_str(self.lower_to_cpp,self.eliminate_dead_code)
+                    func_op =  candidates[index].get_function()
+                    for s in helper_str:
+                        self.logger.critical(s+"\n")
+                    self.logger.critical(func_str)
+                    str_output = io.StringIO()
+                    print(candidates[index].func, file=str_output)
+                    if candidates[index].cond is not None:
+                        print(candidates[index].cond, file=str_output)
+                    print(func_op, file=str_output)
+                    func_op_str = str_output.getvalue()
+                    self.logger.error(func_op_str)
+                    exit(0)
                 candidates.pop(index)
                 continue
 


### PR DESCRIPTION
This PR includes two changes:
1. Add critical and error support in logging functions
2. When detect unsound bit ==4, exit the problem and save both MLIR and cpp file