### PR TITLE
Fix concrete op

### DIFF
--- a/xdsl_smt/utils/synthesizer_utils/solution_set.py
+++ b/xdsl_smt/utils/synthesizer_utils/solution_set.py
@@ -37,7 +37,7 @@ def verify_function(
     if func.cond is not None:
         cur_helper.append(func.cond)
     return verify_transfer_function(
-        func.get_function(), cur_helper + helper_funcs, ctx, 32
+        func.get_function(), concrete_op, cur_helper + helper_funcs, ctx, 32
     )
 
 
@@ -183,7 +183,7 @@ class SolutionSet(ABC):
             if sol.cond is not None:
                 cur_helper.append(sol.cond)
             if not verify_transfer_function(
-                sol.get_function(), cur_helper + helper_funcs, ctx, 16
+                sol.get_function(), concrete_op, cur_helper + helper_funcs, ctx, 16
             ):
                 unsound_lst.append(i)
         for unsound_idx in unsound_lst[::-1]:


### PR DESCRIPTION
This PR includes three following changes:
1. Skip lowering SMT types when lowering
2. Add poison semantics for concrete operations
3. Use update usages of concrete op