### PR TITLE
Eval at bits within [min_bitwidth, bitwidth]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 
 # Debug outputs
 outputs/
+tmp/
 
 # ignore synthed output
 tmp.cpp

--- a/xdsl_smt/benchmark/benchmark.py
+++ b/xdsl_smt/benchmark/benchmark.py
@@ -18,8 +18,10 @@ COND_LEN = 10
 SOL_SIZE = 0
 NUM_ABD_P = 25
 BWIDTH = 4
+MIN_BWIDTH = 1
 WEIGHT_DSL = True
 PROGRAM_LENGTH = 40
+INV_TEMP = 200
 
 # something faster
 # PROGRAM_LENGTH = 40
@@ -76,8 +78,10 @@ def synth_run(args: tuple[str, str, str, int]) -> dict[str, float | str]:
             solution_size=SOL_SIZE,
             num_abd_procs=NUM_ABD_P,
             bitwidth=BWIDTH,
+            min_bitwidth=MIN_BWIDTH,
             weighted_dsl=WEIGHT_DSL,
             program_length=PROGRAM_LENGTH,
+            inv_temp=INV_TEMP,
             random_seed=seed,
             transfer_functions=fname,
             outputs_folder=output_folder,

--- a/xdsl_smt/cli/synth_transfer.py
+++ b/xdsl_smt/cli/synth_transfer.py
@@ -109,6 +109,12 @@ def register_all_arguments(arg_parser: argparse.ArgumentParser):
         help="Specify the bitwidth of the evaluation engine",
     )
     arg_parser.add_argument(
+        "-min_bitwidth",
+        type=int,
+        nargs="?",
+        help="Specify the minimum bitwidth of the evaluation engine",
+    )
+    arg_parser.add_argument(
         "-solution_size",
         type=int,
         nargs="?",
@@ -702,11 +708,12 @@ def save_solution(solution_module: ModuleOp, solution_str: str, outputs_folder: 
 
 def run(
     domain: eval_engine.AbstractDomain,
-    num_programs: int = NUM_PROGRAMS,
-    total_rounds: int = TOTAL_ROUNDS,
-    program_length: int = PROGRAM_LENGTH,
-    inv_temp: int = INV_TEMP,
-    bitwidth: int = SYNTH_WIDTH,
+    num_programs: int,
+    total_rounds: int,
+    program_length: int,
+    inv_temp: int,
+    bitwidth: int,
+    min_bitwidth: int,
     solution_size: int = SOLUTION_SIZE,
     num_iters: int = NUM_ITERS,
     condition_length: int = CONDITION_LENGTH,
@@ -849,7 +856,7 @@ def run(
     ]
 
     data_dir = eval_engine.setup_eval(
-        domain, bitwidth, samples, "\n".join(helper_funcs_cpp)
+        domain, bitwidth, min_bitwidth, samples, "\n".join(helper_funcs_cpp)
     )
 
     base_bodys: dict[str, FuncOp] = {}
@@ -1001,6 +1008,7 @@ def main() -> None:
     )
     inv_temp = INV_TEMP if args.inv_temp is None else args.inv_temp
     bitwidth = SYNTH_WIDTH if args.bitwidth is None else args.bitwidth
+    min_bitwidth = SYNTH_WIDTH if args.min_bitwidth is None else args.min_bitwidth
     solution_size = SOLUTION_SIZE if args.solution_size is None else args.solution_size
     num_iters = NUM_ITERS if args.num_iters is None else args.num_iters
     condition_length = (
@@ -1019,6 +1027,7 @@ def main() -> None:
         program_length=program_length,
         inv_temp=inv_temp,
         bitwidth=bitwidth,
+        min_bitwidth=min_bitwidth,
         solution_size=solution_size,
         num_iters=num_iters,
         condition_length=condition_length,

--- a/xdsl_smt/eval_engine/eval.py
+++ b/xdsl_smt/eval_engine/eval.py
@@ -17,6 +17,7 @@ class AbstractDomain(Enum):
 
 def setup_eval(
     domain: AbstractDomain,
+    min_bitwidth: int,
     bitwidth: int,
     samples: tuple[int, int] | None,
     conc_op_src: str,
@@ -31,6 +32,7 @@ def setup_eval(
     engine_params = ""
     engine_params += f"{dirpath}\n"
     engine_params += f"{domain}\n"
+    engine_params += f"{min_bitwidth}\n"
     engine_params += f"{bitwidth}\n"
     engine_params += f"{samples[0]} {samples[1]}\n" if samples is not None else "\n"
     engine_params += "using A::APInt;\n"

--- a/xdsl_smt/eval_engine/src/Eval.h
+++ b/xdsl_smt/eval_engine/src/Eval.h
@@ -30,6 +30,7 @@ private:
   std::optional<OpConstraintFn> opCon;
   ConcOpFn concOp;
   unsigned int bw;
+  unsigned int lbw;
 
   // methods
   const Domain toBestAbst(const Domain &lhs, const Domain &rhs) {
@@ -44,8 +45,9 @@ private:
   }
 
 public:
-  EnumXfer(std::unique_ptr<llvm::orc::LLJIT> jit0, unsigned int bw0)
-      : jit(std::move(jit0)), bw(bw0) {
+  EnumXfer(std::unique_ptr<llvm::orc::LLJIT> jit0, unsigned int bw0,
+           unsigned int lbw0)
+      : jit(std::move(jit0)), bw(bw0), lbw(lbw0) {
 
     concOp = llvm::cantFail(jit->lookup("concrete_op"))
                  .toPtr<A::APInt(A::APInt, A::APInt)>();
@@ -62,13 +64,13 @@ public:
   }
 
   const std::vector<std::tuple<Domain, Domain, Domain>>
-  genRand(unsigned int seed, unsigned int samples) {
+  genRand(unsigned int seed, unsigned int samples, unsigned int ebw) {
     std::vector<std::tuple<Domain, Domain, Domain>> r;
     std::mt19937 rng(seed);
 
     for (unsigned int i = 0; i < samples; ++i) {
-      Domain lhs = Domain(rng, bw);
-      Domain rhs = Domain(rng, bw);
+      Domain lhs = Domain(rng, ebw);
+      Domain rhs = Domain(rng, ebw);
       Domain res = toBestAbst(lhs, rhs);
       r.push_back({lhs, rhs, res});
     }
@@ -92,9 +94,24 @@ public:
   genAllBws() {
     std::vector<std::vector<std::tuple<Domain, Domain, Domain>>> r;
 
-    for (unsigned int ebw = 1; ebw <= bw; ++ebw)
+    for (unsigned int ebw = lbw; ebw <= bw; ++ebw)
       r.push_back(genLattice(ebw));
 
+    return r;
+  }
+
+  const std::vector<std::vector<std::tuple<Domain, Domain, Domain>>>
+  genAllBwsRand(unsigned int seed, unsigned int samples) {
+    std::vector<std::vector<std::tuple<Domain, Domain, Domain>>> r;
+
+    for (unsigned int ebw = lbw; ebw <= std::min(bw, 4u); ++ebw)
+      r.push_back(genLattice(ebw));
+    if (bw > 4) {
+      unsigned int tmplbw = std::max(5u, lbw);
+      unsigned int sample_per_bw = samples / (bw - tmplbw + 1);
+      for (unsigned int ebw = tmplbw; ebw <= bw; ++ebw)
+        r.push_back(genRand(seed, sample_per_bw, ebw));
+    }
     return r;
   }
 };

--- a/xdsl_smt/eval_engine/src/llvm_eval/common.h
+++ b/xdsl_smt/eval_engine/src/llvm_eval/common.h
@@ -23,5 +23,6 @@ bool nonZeroRhs(const A::APInt &, const A::APInt &);
 opConFn getNW(ovFn);
 opConFn getNW(ovFn, ovFn);
 
-extern const std::vector<std::tuple<std::string, concFn, std::optional<opConFn>>>
+extern const std::vector<
+    std::tuple<std::string, concFn, std::optional<opConFn>>>
     tests;

--- a/xdsl_smt/eval_engine/src/xfer_enum/xfer_enum.cpp
+++ b/xdsl_smt/eval_engine/src/xfer_enum/xfer_enum.cpp
@@ -9,23 +9,17 @@
 
 template <typename D>
 void handleDomain(std::unique_ptr<llvm::orc::LLJIT> jit, unsigned int bw,
+                  unsigned int lbw,
                   std::optional<std::pair<unsigned int, unsigned int>> samples,
                   const std::string dirPath) {
-  EnumXfer<D> e(std::move(jit), bw);
-
-  if (samples) {
-    const std::vector<std::tuple<D, D, D>> data =
-        e.genRand(samples->first, samples->second);
-    const std::string fname = dirPath + "bw " + std::to_string(bw) +
-                              " samples " + std::to_string(data.size());
-    write_vecs(fname, data);
-  } else {
-    std::vector<std::vector<std::tuple<D, D, D>>> r = e.genAllBws();
-    for (unsigned int i = 0; i < r.size(); ++i) {
-      const std::string fname = dirPath + "bw " + std::to_string(i + 1) +
-                                " samples " + std::to_string(r[i].size());
-      write_vecs(fname, r[i]);
-    }
+  EnumXfer<D> e(std::move(jit), bw, lbw);
+  std::vector<std::vector<std::tuple<D, D, D>>> r =
+      samples ? e.genAllBwsRand(samples->first, samples->second)
+              : e.genAllBws();
+  for (unsigned int i = 0; i < r.size(); ++i) {
+    const std::string fname = dirPath + "bw " + std::to_string(i + lbw) +
+                              " samples " + std::to_string(r[i].size());
+    write_vecs(fname, r[i]);
   }
 }
 
@@ -41,6 +35,9 @@ int main() {
   unsigned int bw = static_cast<unsigned int>(std::stoul(tmpStr));
 
   std::getline(std::cin, tmpStr);
+  unsigned int lbw = static_cast<unsigned int>(std::stoul(tmpStr));
+
+  std::getline(std::cin, tmpStr);
   std::vector<std::string> tmpVec = split_whitespace(tmpStr);
   std::optional<std::pair<unsigned int, unsigned int>> samples = std::nullopt;
   if (tmpVec.size() != 0)
@@ -51,11 +48,11 @@ int main() {
   std::unique_ptr<llvm::orc::LLJIT> jit = getJit(fnSrcCode);
 
   if (domain == "KnownBits") {
-    handleDomain<KnownBits>(std::move(jit), bw, samples, fname);
+    handleDomain<KnownBits>(std::move(jit), bw, lbw, samples, fname);
   } else if (domain == "ConstantRange") {
-    handleDomain<ConstantRange>(std::move(jit), bw, samples, fname);
+    handleDomain<ConstantRange>(std::move(jit), bw, lbw, samples, fname);
   } else if (domain == "IntegerModulo") {
-    handleDomain<IntegerModulo<6>>(std::move(jit), bw, samples, fname);
+    handleDomain<IntegerModulo<6>>(std::move(jit), bw, lbw, samples, fname);
   } else
     std::cerr << "Unknown domain: " << domain << "\n";
 

--- a/xdsl_smt/eval_engine/src/xfer_enum/xfer_enum.cpp
+++ b/xdsl_smt/eval_engine/src/xfer_enum/xfer_enum.cpp
@@ -8,11 +8,11 @@
 #include "../utils.cpp"
 
 template <typename D>
-void handleDomain(std::unique_ptr<llvm::orc::LLJIT> jit, unsigned int bw,
+void handleDomain(std::unique_ptr<llvm::orc::LLJIT> jit, unsigned int ubw,
                   unsigned int lbw,
                   std::optional<std::pair<unsigned int, unsigned int>> samples,
                   const std::string dirPath) {
-  EnumXfer<D> e(std::move(jit), bw, lbw);
+  EnumXfer<D> e(std::move(jit), ubw, lbw);
   std::vector<std::vector<std::tuple<D, D, D>>> r =
       samples ? e.genAllBwsRand(samples->first, samples->second)
               : e.genAllBws();
@@ -32,7 +32,7 @@ int main() {
 
   std::string tmpStr;
   std::getline(std::cin, tmpStr);
-  unsigned int bw = static_cast<unsigned int>(std::stoul(tmpStr));
+  unsigned int ubw = static_cast<unsigned int>(std::stoul(tmpStr));
 
   std::getline(std::cin, tmpStr);
   unsigned int lbw = static_cast<unsigned int>(std::stoul(tmpStr));
@@ -48,11 +48,11 @@ int main() {
   std::unique_ptr<llvm::orc::LLJIT> jit = getJit(fnSrcCode);
 
   if (domain == "KnownBits") {
-    handleDomain<KnownBits>(std::move(jit), bw, lbw, samples, fname);
+    handleDomain<KnownBits>(std::move(jit), ubw, lbw, samples, fname);
   } else if (domain == "ConstantRange") {
-    handleDomain<ConstantRange>(std::move(jit), bw, lbw, samples, fname);
+    handleDomain<ConstantRange>(std::move(jit), ubw, lbw, samples, fname);
   } else if (domain == "IntegerModulo") {
-    handleDomain<IntegerModulo<6>>(std::move(jit), bw, lbw, samples, fname);
+    handleDomain<IntegerModulo<6>>(std::move(jit), ubw, lbw, samples, fname);
   } else
     std::cerr << "Unknown domain: " << domain << "\n";
 

--- a/xdsl_smt/eval_engine/tester.py
+++ b/xdsl_smt/eval_engine/tester.py
@@ -168,22 +168,22 @@ kb_or_test = TestInput(
     [kb_xor, kb_and, kb_or],
     [
         """
-bw: 1 all: 9     s: 8     e: 6     uall: 6     us: 5     ue: 3     dis: 4     udis: 4     bdis: 6     sdis: 3
-bw: 2 all: 81    s: 64    e: 36    uall: 72    us: 55    ue: 27    dis: 72    udis: 72    bdis: 108   sdis: 60
-bw: 3 all: 729   s: 512   e: 216   uall: 702   us: 485   ue: 189   dis: 972   udis: 972   bdis: 1458  sdis: 882
-bw: 4 all: 6561  s: 4096  e: 1296  uall: 6480  us: 4015  ue: 1215  dis: 11664 udis: 11664 bdis: 17496 sdis: 11352
+bw: 1  all: 9     s: 8     e: 6     uall: 6     us: 5     ue: 3     dis: 4     udis: 4     bdis: 6     sdis: 3
+bw: 2  all: 81    s: 64    e: 36    uall: 72    us: 55    ue: 27    dis: 72    udis: 72    bdis: 108   sdis: 60
+bw: 3  all: 729   s: 512   e: 216   uall: 702   us: 485   ue: 189   dis: 972   udis: 972   bdis: 1458  sdis: 882
+bw: 4  all: 6561  s: 4096  e: 1296  uall: 6480  us: 4015  ue: 1215  dis: 11664 udis: 11664 bdis: 17496 sdis: 11352
         """,
         """
-bw: 1 all: 9     s: 5     e: 3     uall: 6     us: 4     ue: 2     dis: 8     udis: 6     bdis: 6     sdis: 4
-bw: 2 all: 81    s: 25    e: 9     uall: 72    us: 24    ue: 8     dis: 144   udis: 132   bdis: 108   sdis: 88
-bw: 3 all: 729   s: 125   e: 27    uall: 702   us: 124   ue: 26    dis: 1944  udis: 1890  bdis: 1458  sdis: 1308
-bw: 4 all: 6561  s: 625   e: 81    uall: 6480  us: 624   ue: 80    dis: 23328 udis: 23112 bdis: 17496 sdis: 16496
+bw: 1  all: 9     s: 5     e: 3     uall: 6     us: 4     ue: 2     dis: 8     udis: 6     bdis: 6     sdis: 4
+bw: 2  all: 81    s: 25    e: 9     uall: 72    us: 24    ue: 8     dis: 144   udis: 132   bdis: 108   sdis: 88
+bw: 3  all: 729   s: 125   e: 27    uall: 702   us: 124   ue: 26    dis: 1944  udis: 1890  bdis: 1458  sdis: 1308
+bw: 4  all: 6561  s: 625   e: 81    uall: 6480  us: 624   ue: 80    dis: 23328 udis: 23112 bdis: 17496 sdis: 16496
         """,
         """
-bw: 1 all: 9     s: 9     e: 9     uall: 6     us: 6     ue: 6     dis: 0     udis: 0     bdis: 6     sdis: 0
-bw: 2 all: 81    s: 81    e: 81    uall: 72    us: 72    ue: 72    dis: 0     udis: 0     bdis: 108   sdis: 0
-bw: 3 all: 729   s: 729   e: 729   uall: 702   us: 702   ue: 702   dis: 0     udis: 0     bdis: 1458  sdis: 0
-bw: 4 all: 6561  s: 6561  e: 6561  uall: 6480  us: 6480  ue: 6480  dis: 0     udis: 0     bdis: 17496 sdis: 0
+bw: 1  all: 9     s: 9     e: 9     uall: 6     us: 6     ue: 6     dis: 0     udis: 0     bdis: 6     sdis: 0
+bw: 2  all: 81    s: 81    e: 81    uall: 72    us: 72    ue: 72    dis: 0     udis: 0     bdis: 108   sdis: 0
+bw: 3  all: 729   s: 729   e: 729   uall: 702   us: 702   ue: 702   dis: 0     udis: 0     bdis: 1458  sdis: 0
+bw: 4  all: 6561  s: 6561  e: 6561  uall: 6480  us: 6480  ue: 6480  dis: 0     udis: 0     bdis: 17496 sdis: 0
         """,
     ],
 )
@@ -195,22 +195,22 @@ kb_and_test = TestInput(
     [kb_xor, kb_and, kb_or],
     [
         """
-bw: 1 all: 9     s: 6     e: 4     uall: 6     us: 3     ue: 1     dis: 8     udis: 8     bdis: 6     sdis: 5
-bw: 2 all: 81    s: 36    e: 16    uall: 72    us: 27    ue: 7     dis: 144   udis: 144   bdis: 108   sdis: 96
-bw: 3 all: 729   s: 216   e: 64    uall: 702   us: 189   ue: 37    dis: 1944  udis: 1944  bdis: 1458  sdis: 1350
-bw: 4 all: 6561  s: 1296  e: 256   uall: 6480  us: 1215  ue: 175   dis: 23328 udis: 23328 bdis: 17496 sdis: 16632
+bw: 1  all: 9     s: 6     e: 4     uall: 6     us: 3     ue: 1     dis: 8     udis: 8     bdis: 6     sdis: 5
+bw: 2  all: 81    s: 36    e: 16    uall: 72    us: 27    ue: 7     dis: 144   udis: 144   bdis: 108   sdis: 96
+bw: 3  all: 729   s: 216   e: 64    uall: 702   us: 189   ue: 37    dis: 1944  udis: 1944  bdis: 1458  sdis: 1350
+bw: 4  all: 6561  s: 1296  e: 256   uall: 6480  us: 1215  ue: 175   dis: 23328 udis: 23328 bdis: 17496 sdis: 16632
         """,
         """
-bw: 1 all: 9     s: 9     e: 9     uall: 6     us: 6     ue: 6     dis: 0     udis: 0     bdis: 6     sdis: 0
-bw: 2 all: 81    s: 81    e: 81    uall: 72    us: 72    ue: 72    dis: 0     udis: 0     bdis: 108   sdis: 0
-bw: 3 all: 729   s: 729   e: 729   uall: 702   us: 702   ue: 702   dis: 0     udis: 0     bdis: 1458  sdis: 0
-bw: 4 all: 6561  s: 6561  e: 6561  uall: 6480  us: 6480  ue: 6480  dis: 0     udis: 0     bdis: 17496 sdis: 0
+bw: 1  all: 9     s: 9     e: 9     uall: 6     us: 6     ue: 6     dis: 0     udis: 0     bdis: 6     sdis: 0
+bw: 2  all: 81    s: 81    e: 81    uall: 72    us: 72    ue: 72    dis: 0     udis: 0     bdis: 108   sdis: 0
+bw: 3  all: 729   s: 729   e: 729   uall: 702   us: 702   ue: 702   dis: 0     udis: 0     bdis: 1458  sdis: 0
+bw: 4  all: 6561  s: 6561  e: 6561  uall: 6480  us: 6480  ue: 6480  dis: 0     udis: 0     bdis: 17496 sdis: 0
         """,
         """
-bw: 1 all: 9     s: 5     e: 3     uall: 6     us: 4     ue: 2     dis: 8     udis: 6     bdis: 6     sdis: 4
-bw: 2 all: 81    s: 25    e: 9     uall: 72    us: 24    ue: 8     dis: 144   udis: 132   bdis: 108   sdis: 88
-bw: 3 all: 729   s: 125   e: 27    uall: 702   us: 124   ue: 26    dis: 1944  udis: 1890  bdis: 1458  sdis: 1308
-bw: 4 all: 6561  s: 625   e: 81    uall: 6480  us: 624   ue: 80    dis: 23328 udis: 23112 bdis: 17496 sdis: 16496
+bw: 1  all: 9     s: 5     e: 3     uall: 6     us: 4     ue: 2     dis: 8     udis: 6     bdis: 6     sdis: 4
+bw: 2  all: 81    s: 25    e: 9     uall: 72    us: 24    ue: 8     dis: 144   udis: 132   bdis: 108   sdis: 88
+bw: 3  all: 729   s: 125   e: 27    uall: 702   us: 124   ue: 26    dis: 1944  udis: 1890  bdis: 1458  sdis: 1308
+bw: 4  all: 6561  s: 625   e: 81    uall: 6480  us: 624   ue: 80    dis: 23328 udis: 23112 bdis: 17496 sdis: 16496
         """,
     ],
 )
@@ -222,22 +222,22 @@ kb_xor_test = TestInput(
     [kb_xor, kb_and, kb_or],
     [
         """
-bw: 1 all: 9     s: 9     e: 9     uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
-bw: 2 all: 81    s: 81    e: 81    uall: 56    us: 56    ue: 56    dis: 0     udis: 0     bdis: 72    sdis: 0
-bw: 3 all: 729   s: 729   e: 729   uall: 604   us: 604   ue: 604   dis: 0     udis: 0     bdis: 972   sdis: 0
-bw: 4 all: 6561  s: 6561  e: 6561  uall: 5936  us: 5936  ue: 5936  dis: 0     udis: 0     bdis: 11664 sdis: 0
+bw: 1  all: 9     s: 9     e: 9     uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
+bw: 2  all: 81    s: 81    e: 81    uall: 56    us: 56    ue: 56    dis: 0     udis: 0     bdis: 72    sdis: 0
+bw: 3  all: 729   s: 729   e: 729   uall: 604   us: 604   ue: 604   dis: 0     udis: 0     bdis: 972   sdis: 0
+bw: 4  all: 6561  s: 6561  e: 6561  uall: 5936  us: 5936  ue: 5936  dis: 0     udis: 0     bdis: 11664 sdis: 0
         """,
         """
-bw: 1 all: 9     s: 4     e: 4     uall: 4     us: 1     ue: 1     dis: 8     udis: 6     bdis: 4     sdis: 3
-bw: 2 all: 81    s: 16    e: 16    uall: 56    us: 7     ue: 7     dis: 144   udis: 124   bdis: 72    sdis: 64
-bw: 3 all: 729   s: 64    e: 64    uall: 604   us: 37    ue: 37    dis: 1944  udis: 1794  bdis: 972   sdis: 924
-bw: 4 all: 6561  s: 256   e: 256   uall: 5936  us: 175   ue: 175   dis: 23328 udis: 22328 bdis: 11664 sdis: 11408
+bw: 1  all: 9     s: 4     e: 4     uall: 4     us: 1     ue: 1     dis: 8     udis: 6     bdis: 4     sdis: 3
+bw: 2  all: 81    s: 16    e: 16    uall: 56    us: 7     ue: 7     dis: 144   udis: 124   bdis: 72    sdis: 64
+bw: 3  all: 729   s: 64    e: 64    uall: 604   us: 37    ue: 37    dis: 1944  udis: 1794  bdis: 972   sdis: 924
+bw: 4  all: 6561  s: 256   e: 256   uall: 5936  us: 175   ue: 175   dis: 23328 udis: 22328 bdis: 11664 sdis: 11408
         """,
         """
-bw: 1 all: 9     s: 6     e: 6     uall: 4     us: 3     ue: 3     dis: 4     udis: 2     bdis: 4     sdis: 1
-bw: 2 all: 81    s: 36    e: 36    uall: 56    us: 27    ue: 27    dis: 72    udis: 52    bdis: 72    sdis: 36
-bw: 3 all: 729   s: 216   e: 216   uall: 604   us: 189   ue: 189   dis: 972   udis: 822   bdis: 972   sdis: 648
-bw: 4 all: 6561  s: 1296  e: 1296  uall: 5936  us: 1215  ue: 1215  dis: 11664 udis: 10664 bdis: 11664 sdis: 9072
+bw: 1  all: 9     s: 6     e: 6     uall: 4     us: 3     ue: 3     dis: 4     udis: 2     bdis: 4     sdis: 1
+bw: 2  all: 81    s: 36    e: 36    uall: 56    us: 27    ue: 27    dis: 72    udis: 52    bdis: 72    sdis: 36
+bw: 3  all: 729   s: 216   e: 216   uall: 604   us: 189   ue: 189   dis: 972   udis: 822   bdis: 972   sdis: 648
+bw: 4  all: 6561  s: 1296  e: 1296  uall: 5936  us: 1215  ue: 1215  dis: 11664 udis: 10664 bdis: 11664 sdis: 9072
         """,
     ],
 )
@@ -249,22 +249,22 @@ kb_add_test = TestInput(
     [kb_xor, kb_and, kb_or],
     [
         """
-bw: 1 all: 9     s: 9     e: 9     uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
-bw: 2 all: 81    s: 65    e: 65    uall: 44    us: 40    ue: 40    dis: 20    udis: 8     bdis: 60    sdis: 8
-bw: 3 all: 729   s: 425   e: 425   uall: 436   us: 300   ue: 300   dis: 440   udis: 248   bdis: 708   sdis: 228
-bw: 4 all: 6561  s: 2625  e: 2625  uall: 4220  us: 2000  ue: 2000  dis: 6620  udis: 4328  bdis: 7692  sdis: 3892
+bw: 1  all: 9     s: 9     e: 9     uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
+bw: 2  all: 81    s: 65    e: 65    uall: 44    us: 40    ue: 40    dis: 20    udis: 8     bdis: 60    sdis: 8
+bw: 3  all: 729   s: 425   e: 425   uall: 436   us: 300   ue: 300   dis: 440   udis: 248   bdis: 708   sdis: 228
+bw: 4  all: 6561  s: 2625  e: 2625  uall: 4220  us: 2000  ue: 2000  dis: 6620  udis: 4328  bdis: 7692  sdis: 3892
         """,
         """
-bw: 1 all: 9     s: 4     e: 4     uall: 4     us: 1     ue: 1     dis: 8     udis: 6     bdis: 4     sdis: 3
-bw: 2 all: 81    s: 13    e: 13    uall: 44    us: 4     ue: 4     dis: 134   udis: 102   bdis: 60    sdis: 55
-bw: 3 all: 729   s: 40    e: 40    uall: 436   us: 13    ue: 13    dis: 1724  udis: 1310  bdis: 708   sdis: 690
-bw: 4 all: 6561  s: 121   e: 121   uall: 4220  us: 40    ue: 40    dis: 20018 udis: 15358 bdis: 7692  sdis: 7634
+bw: 1  all: 9     s: 4     e: 4     uall: 4     us: 1     ue: 1     dis: 8     udis: 6     bdis: 4     sdis: 3
+bw: 2  all: 81    s: 13    e: 13    uall: 44    us: 4     ue: 4     dis: 134   udis: 102   bdis: 60    sdis: 55
+bw: 3  all: 729   s: 40    e: 40    uall: 436   us: 13    ue: 13    dis: 1724  udis: 1310  bdis: 708   sdis: 690
+bw: 4  all: 6561  s: 121   e: 121   uall: 4220  us: 40    ue: 40    dis: 20018 udis: 15358 bdis: 7692  sdis: 7634
         """,
         """
-bw: 1 all: 9     s: 6     e: 6     uall: 4     us: 3     ue: 3     dis: 4     udis: 2     bdis: 4     sdis: 1
-bw: 2 all: 81    s: 33    e: 33    uall: 44    us: 24    ue: 24    dis: 82    udis: 42    bdis: 60    sdis: 27
-bw: 3 all: 729   s: 174   e: 174   uall: 436   us: 147   ue: 147   dis: 1192  udis: 690   bdis: 708   sdis: 444
-bw: 4 all: 6561  s: 897   e: 897   uall: 4220  us: 816   ue: 816   dis: 14974 udis: 9554  bdis: 7692  sdis: 5850
+bw: 1  all: 9     s: 6     e: 6     uall: 4     us: 3     ue: 3     dis: 4     udis: 2     bdis: 4     sdis: 1
+bw: 2  all: 81    s: 33    e: 33    uall: 44    us: 24    ue: 24    dis: 82    udis: 42    bdis: 60    sdis: 27
+bw: 3  all: 729   s: 174   e: 174   uall: 436   us: 147   ue: 147   dis: 1192  udis: 690   bdis: 708   sdis: 444
+bw: 4  all: 6561  s: 897   e: 897   uall: 4220  us: 816   ue: 816   dis: 14974 udis: 9554  bdis: 7692  sdis: 5850
         """,
     ],
 )
@@ -276,16 +276,16 @@ cr_add_test = TestInput(
     [cr_add, cr_sub],
     [
         """
-bw: 1 all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
-bw: 2 all: 121   s: 121   e: 121   uall: 46    us: 46    ue: 46    dis: 0     udis: 0     bdis: 96    sdis: 0
-bw: 3 all: 1369  s: 1369  e: 1369  uall: 532   us: 532   ue: 532   dis: 0     udis: 0     bdis: 2352  sdis: 0
-bw: 4 all: 18769 s: 18769 e: 18769 uall: 6920  us: 6920  ue: 6920  dis: 0     udis: 0     bdis: 63648 sdis: 0
+bw: 1  all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
+bw: 2  all: 121   s: 121   e: 121   uall: 46    us: 46    ue: 46    dis: 0     udis: 0     bdis: 96    sdis: 0
+bw: 3  all: 1369  s: 1369  e: 1369  uall: 532   us: 532   ue: 532   dis: 0     udis: 0     bdis: 2352  sdis: 0
+bw: 4  all: 18769 s: 18769 e: 18769 uall: 6920  us: 6920  ue: 6920  dis: 0     udis: 0     bdis: 63648 sdis: 0
         """,
         """
-bw: 1 all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
-bw: 2 all: 121   s: 92    e: 80    uall: 46    us: 29    ue: 17    dis: 88    udis: 71    bdis: 96    sdis: 58
-bw: 3 all: 1369  s: 912   e: 709   uall: 532   us: 278   ue: 75    dis: 2620  udis: 1950  bdis: 2352  sdis: 1994
-bw: 4 all: 18769 s: 12224 e: 9179  uall: 6920  us: 3420  ue: 375   dis: 75432 udis: 53340 bdis: 63648 sdis: 59948
+bw: 1  all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
+bw: 2  all: 121   s: 92    e: 80    uall: 46    us: 29    ue: 17    dis: 88    udis: 71    bdis: 96    sdis: 58
+bw: 3  all: 1369  s: 912   e: 709   uall: 532   us: 278   ue: 75    dis: 2620  udis: 1950  bdis: 2352  sdis: 1994
+bw: 4  all: 18769 s: 12224 e: 9179  uall: 6920  us: 3420  ue: 375   dis: 75432 udis: 53340 bdis: 63648 sdis: 59948
         """,
     ],
 )
@@ -297,16 +297,16 @@ cr_sub_test = TestInput(
     [cr_sub, cr_add],
     [
         """
-bw: 1 all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
-bw: 2 all: 121   s: 121   e: 121   uall: 46    us: 46    ue: 46    dis: 0     udis: 0     bdis: 96    sdis: 0
-bw: 3 all: 1369  s: 1369  e: 1369  uall: 532   us: 532   ue: 532   dis: 0     udis: 0     bdis: 2352  sdis: 0
-bw: 4 all: 18769 s: 18769 e: 18769 uall: 6920  us: 6920  ue: 6920  dis: 0     udis: 0     bdis: 63648 sdis: 0
+bw: 1  all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
+bw: 2  all: 121   s: 121   e: 121   uall: 46    us: 46    ue: 46    dis: 0     udis: 0     bdis: 96    sdis: 0
+bw: 3  all: 1369  s: 1369  e: 1369  uall: 532   us: 532   ue: 532   dis: 0     udis: 0     bdis: 2352  sdis: 0
+bw: 4  all: 18769 s: 18769 e: 18769 uall: 6920  us: 6920  ue: 6920  dis: 0     udis: 0     bdis: 63648 sdis: 0
         """,
         """
-bw: 1 all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
-bw: 2 all: 121   s: 92    e: 80    uall: 46    us: 29    ue: 17    dis: 88    udis: 71    bdis: 96    sdis: 58
-bw: 3 all: 1369  s: 912   e: 709   uall: 532   us: 278   ue: 75    dis: 2620  udis: 1950  bdis: 2352  sdis: 1994
-bw: 4 all: 18769 s: 12224 e: 9179  uall: 6920  us: 3420  ue: 375   dis: 75432 udis: 53340 bdis: 63648 sdis: 59948
+bw: 1  all: 16    s: 16    e: 16    uall: 4     us: 4     ue: 4     dis: 0     udis: 0     bdis: 4     sdis: 0
+bw: 2  all: 121   s: 92    e: 80    uall: 46    us: 29    ue: 17    dis: 88    udis: 71    bdis: 96    sdis: 58
+bw: 3  all: 1369  s: 912   e: 709   uall: 532   us: 278   ue: 75    dis: 2620  udis: 1950  bdis: 2352  sdis: 1994
+bw: 4  all: 18769 s: 12224 e: 9179  uall: 6920  us: 3420  ue: 375   dis: 75432 udis: 53340 bdis: 63648 sdis: 59948
         """,
     ],
 )

--- a/xdsl_smt/eval_engine/tester.py
+++ b/xdsl_smt/eval_engine/tester.py
@@ -139,9 +139,9 @@ def test(input: TestInput) -> None:
         if input.op_constraint is None
         else [input.concrete_op, input.op_constraint]
     )
-
+    lbw = 1
     bw = 4
-    data_dir = setup_eval(input.domain, bw, None, "\n".join(helpers))
+    data_dir = setup_eval(input.domain, bw, lbw, None, "\n".join(helpers))
 
     results = eval_transfer_func(
         data_dir, list(names), list(srcs), [], [], helpers, input.domain


### PR DESCRIPTION
The PR includes:
1. Add a new cmd flag `min_bitwidth`. The evaluation engine evals at bits within [min_bitwidth, bitwidth].
2. Always evaluate on the entire input space for bw <= 4, even if in the random test mode.