### PR TITLE
Add APInt operators

### DIFF
--- a/xdsl_smt/eval_engine/src/APInt.h
+++ b/xdsl_smt/eval_engine/src/APInt.h
@@ -73,6 +73,12 @@ public:
     return Res;
   }
 
+  static APInt getHighBitsSet(unsigned numBits, unsigned hiBitsSet) {
+    APInt Res(numBits, 0);
+    Res.setHighBits(hiBitsSet);
+    return Res;
+  }
+
   static APInt getLowBitsSet(unsigned numBits, unsigned loBitsSet) {
     APInt Res(numBits, 0);
     Res.setLowBits(loBitsSet);
@@ -757,6 +763,18 @@ public:
   }
 
   void clearSignBit() { clearBit(BitWidth - 1); }
+
+  /// Set bottom loBits bits to 0.
+  void clearLowBits(unsigned loBits) {
+    APInt Keep = getHighBitsSet(BitWidth, BitWidth - loBits);
+    *this &= Keep;
+  }
+
+  /// Set top hiBits bits to 0.
+  void clearHighBits(unsigned hiBits) {
+    APInt Keep = getLowBitsSet(BitWidth, BitWidth - hiBits);
+    *this &= Keep;
+  }
 
   void flipAllBits() {
     VAL ^= WORDTYPE_MAX;

--- a/xdsl_smt/semantics/transfer_semantics.py
+++ b/xdsl_smt/semantics/transfer_semantics.py
@@ -701,7 +701,7 @@ class ClearSignBitOpSemantics(OperationSemantics):
         operand_type = operand.type
         assert isinstance(operand_type, smt_bv.BitVectorType)
         width = operand_type.width.data
-        signed_max_value = smt_bv.ConstantOp(1 << (width - 1) - 1, width)
+        signed_max_value = smt_bv.ConstantOp((1 << (width - 1)) - 1, width)
         and_op = smt_bv.AndOp(signed_max_value.res, operand)
         result = [signed_max_value, and_op]
 


### PR DESCRIPTION
This PR includes:
1. Fix a bug in transfer_semantics.py
2. Add missing operators in APInt.h