### PR TITLE
fix bugger behavior on int mod on low bw's

### DIFF
--- a/xdsl_smt/eval_engine/src/APInt.h
+++ b/xdsl_smt/eval_engine/src/APInt.h
@@ -1235,6 +1235,10 @@ constexpr unsigned char primes[32] = {
     2,  3,  5,  7,  11, 13, 17, 19, 23, 29,  31,  37,  41,  43,  47,  53,
     59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131};
 
+inline bool primeOv(unsigned int bw, unsigned int i) {
+  return IM::primes[i] > A::APInt::getMaxValue(bw).getZExtValue();
+}
+
 inline unsigned long modInv(long a, long b) {
   long b0 = b, t, q;
   long x0 = 0, x1 = 1;
@@ -1252,7 +1256,7 @@ template <unsigned int N> A::APInt crt(const Vec<N> &x, const A::APInt p) {
   unsigned long crt = 0;
 
   for (unsigned int i = 0; i < N; ++i) {
-    if (x[i] == primes[i])
+    if (x[i] == primes[i] || primeOv(x[i].getBitWidth(), i))
       continue;
     unsigned long pp = p.getZExtValue() / primes[i];
     crt += x[i].getZExtValue() * modInv(static_cast<long>(pp), primes[i]) * pp;
@@ -1264,7 +1268,7 @@ template <unsigned int N> A::APInt crt(const Vec<N> &x, const A::APInt p) {
 template <unsigned int N> A::APInt prod(const Vec<N> &x) {
   unsigned long p = 1;
   for (unsigned int i = 0; i < N; ++i)
-    if (x.v[i] != primes[i])
+    if (x[i] != primes[i] && !primeOv(x[i].getBitWidth(), i))
       p *= primes[i];
 
   return A::APInt(64, p);

--- a/xdsl_smt/eval_engine/tester.py
+++ b/xdsl_smt/eval_engine/tester.py
@@ -121,7 +121,9 @@ extern "C" Vec<N> im_add_nsw(const Vec<N> &lhs, const Vec<N> &rhs) {
 
   Vec<N> x(bw);
   for (unsigned int i = 0; i < N; ++i)
-    if (small_lhs[i] != IM::primes[i] && small_rhs[i] != IM::primes[i])
+    if (IM::primes[i] > A::APInt::getMaxValue(bw).getZExtValue())
+      x[i] = 0;
+    else if (small_lhs[i] != IM::primes[i] && small_rhs[i] != IM::primes[i])
       x[i] = (small_lhs[i] + small_rhs[i]).urem(IM::primes[i]);
     else
       x[i] = IM::primes[i];
@@ -317,7 +319,12 @@ im_add_nsw_test = TestInput(
     AbstractDomain.IntegerModulo,
     [im_add_nsw],
     [
-        "all: 2971	s: 2971	e: 2971	p: 0	unsolved:2182	us: 2182	ue: 2182	up: 0	basep: 6964",
+        """
+bw: 1  all: 0     s: 0     e: 0     uall: 0     us: 0     ue: 0     dis: 0     udis: 0     bdis: 0     sdis: 0
+bw: 2  all: 56    s: 56    e: 56    uall: 41    us: 41    ue: 41    dis: 0     udis: 0     bdis: 68    sdis: 0
+bw: 3  all: 356   s: 356   e: 356   uall: 271   us: 271   ue: 271   dis: 0     udis: 0     bdis: 696   sdis: 0
+bw: 4  all: 2971  s: 2971  e: 2971  uall: 2182  us: 2182  ue: 2182  dis: 0     udis: 0     bdis: 6964  sdis: 0
+        """,
     ],
 )
 
@@ -329,5 +336,4 @@ if __name__ == "__main__":
     test(kb_add_test)
     test(cr_add_test)
     test(cr_sub_test)
-    print("TODO skipped IM test")
-    # test(im_add_nsw_test)
+    test(im_add_nsw_test)


### PR DESCRIPTION
Fix a bug where IntMod ends up in an infinite loop when `enumVals` is run on low bitwidths