### PR TITLE
Fix verif pt2

### DIFF
--- a/tests/synth/Operations/Add.mlir
+++ b/tests/synth/Operations/Add.mlir
@@ -1,6 +1,12 @@
 "builtin.module"() ({
   "func.func"() ({
+  ^bb0(%arg0: !transfer.integer, %arg1: !transfer.integer):
+    %result = "transfer.add"(%arg0, %arg1) : (!transfer.integer, !transfer.integer) ->!transfer.integer
+    "func.return"(%result) : (!transfer.integer) -> ()
+  }) {function_type = (!transfer.integer,!transfer.integer) -> !transfer.integer, sym_name = "concrete_op"} : () -> ()
+
+  "func.func"() ({
   ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %arg1: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
     "func.return"(%arg0) : (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> ()
-  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "AddImpl", applied_to=["comb.add"], CPPCLASS=["circt::comb::AddOp"], is_forward=true} : () -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "SAddSatImpl", applied_to=["comb.xx"], CPPCLASS=["circt::comb::XXXOp"], is_forward=true} : () -> ()
 }): () -> ()

--- a/tests/synth/Operations/And.mlir
+++ b/tests/synth/Operations/And.mlir
@@ -1,6 +1,12 @@
 "builtin.module"() ({
   "func.func"() ({
+  ^bb0(%arg0: !transfer.integer, %arg1: !transfer.integer):
+    %result = "transfer.and"(%arg0, %arg1) : (!transfer.integer, !transfer.integer) ->!transfer.integer
+    "func.return"(%result) : (!transfer.integer) -> ()
+  }) {function_type = (!transfer.integer,!transfer.integer) -> !transfer.integer, sym_name = "concrete_op"} : () -> ()
+
+  "func.func"() ({
   ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %arg1: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
     "func.return"(%arg0) : (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> ()
-  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "ANDImpl", applied_to=["comb.and"], CPPCLASS=["circt::comb::AndOp"], is_forward=true} : () -> ()
-}) : () -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "SAddSatImpl", applied_to=["comb.xx"], CPPCLASS=["circt::comb::XXXOp"], is_forward=true} : () -> ()
+}): () -> ()

--- a/tests/synth/Operations/Mul.mlir
+++ b/tests/synth/Operations/Mul.mlir
@@ -1,6 +1,12 @@
 "builtin.module"() ({
   "func.func"() ({
+  ^bb0(%arg0: !transfer.integer, %arg1: !transfer.integer):
+    %result = "transfer.mul"(%arg0, %arg1) : (!transfer.integer, !transfer.integer) ->!transfer.integer
+    "func.return"(%result) : (!transfer.integer) -> ()
+  }) {function_type = (!transfer.integer,!transfer.integer) -> !transfer.integer, sym_name = "concrete_op"} : () -> ()
+
+  "func.func"() ({
   ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %arg1: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
     "func.return"(%arg0) : (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> ()
-  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "MULImpl", applied_to=["comb.mul"], CPPCLASS=["circt::comb::MulOp"], is_forward=true} : () -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "SAddSatImpl", applied_to=["comb.xx"], CPPCLASS=["circt::comb::XXXOp"], is_forward=true} : () -> ()
 }): () -> ()

--- a/tests/synth/Operations/Udiv.mlir
+++ b/tests/synth/Operations/Udiv.mlir
@@ -9,7 +9,13 @@
   }) {function_type = (!transfer.integer, !transfer.integer) -> i1, sym_name = "op_constraint"} : () -> ()
 
   "func.func"() ({
+  ^bb0(%arg0: !transfer.integer, %arg1: !transfer.integer):
+    %result = "transfer.udiv"(%arg0, %arg1) : (!transfer.integer, !transfer.integer) ->!transfer.integer
+    "func.return"(%result) : (!transfer.integer) -> ()
+  }) {function_type = (!transfer.integer,!transfer.integer) -> !transfer.integer, sym_name = "concrete_op"} : () -> ()
+
+  "func.func"() ({
   ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %arg1: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
     "func.return"(%arg0) : (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> ()
-  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "UDIVImpl", applied_to=["comb.divu"], CPPCLASS=["circt::comb::UDIVOp"], is_forward=true} : () -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "SAddSatImpl", applied_to=["comb.xx"], CPPCLASS=["circt::comb::XXXOp"], is_forward=true} : () -> ()
 }) : () -> ()

--- a/tests/synth/Operations/UdivExact.mlir
+++ b/tests/synth/Operations/UdivExact.mlir
@@ -14,7 +14,13 @@
   }) {function_type = (!transfer.integer, !transfer.integer) -> i1, sym_name = "op_constraint"} : () -> ()
 
   "func.func"() ({
+  ^bb0(%arg0: !transfer.integer, %arg1: !transfer.integer):
+    %result = "transfer.udiv"(%arg0, %arg1) : (!transfer.integer, !transfer.integer) ->!transfer.integer
+    "func.return"(%result) : (!transfer.integer) -> ()
+  }) {function_type = (!transfer.integer,!transfer.integer) -> !transfer.integer, sym_name = "concrete_op"} : () -> ()
+
+  "func.func"() ({
   ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %arg1: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
     "func.return"(%arg0) : (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> ()
-  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "UDIVImpl", applied_to=["comb.divu"], CPPCLASS=["circt::comb::UDIVOp"], is_forward=true} : () -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "SAddSatImpl", applied_to=["comb.xx"], CPPCLASS=["circt::comb::XXXOp"], is_forward=true} : () -> ()
 }) : () -> ()

--- a/tests/synth/Operations/Umax.mlir
+++ b/tests/synth/Operations/Umax.mlir
@@ -8,5 +8,5 @@
   "func.func"() ({
   ^bb0(%arg0: !transfer.abs_value<[!transfer.integer,!transfer.integer]>, %arg1: !transfer.abs_value<[!transfer.integer,!transfer.integer]>):
     "func.return"(%arg0) : (!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> ()
-  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "UMaxImpl", applied_to=["comb.umax"], CPPCLASS=["circt::comb::UMaxOp"], is_forward=true} : () -> ()
+  }) {function_type = (!transfer.abs_value<[!transfer.integer,!transfer.integer]>,!transfer.abs_value<[!transfer.integer,!transfer.integer]>) -> !transfer.abs_value<[!transfer.integer,!transfer.integer]>, sym_name = "SAddSatImpl", applied_to=["comb.xx"], CPPCLASS=["circt::comb::XXXOp"], is_forward=true} : () -> ()
 }): () -> ()

--- a/xdsl_smt/dialects/smt_bitvector_dialect.py
+++ b/xdsl_smt/dialects/smt_bitvector_dialect.py
@@ -267,9 +267,19 @@ class MulOp(BinaryBVOp, SimpleSMTLibOp):
         return "bvmul"
 
 
+class URemCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import URemFold
+
+        return (URemFold(),)
+
+
 @irdl_op_definition
 class URemOp(BinaryBVOp, SimpleSMTLibOp):
     name = "smt.bv.urem"
+
+    traits = traits_def(traits.Pure(), URemCanonicalizationPatterns())
 
     def op_name(self) -> str:
         return "bvurem"
@@ -278,9 +288,7 @@ class URemOp(BinaryBVOp, SimpleSMTLibOp):
 class SRemCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl_smt.passes.canonicalization_patterns.smt_bv import (
-            SRemFold,
-        )
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import SRemFold
 
         return (SRemFold(),)
 
@@ -330,9 +338,7 @@ class AShrOp(BinaryBVOp, SimpleSMTLibOp):
 class SDivCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl_smt.passes.canonicalization_patterns.smt_bv import (
-            SDivFold,
-        )
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import SDivFold
 
         return (SDivFold(),)
 
@@ -347,9 +353,19 @@ class SDivOp(BinaryBVOp, SimpleSMTLibOp):
         return "bvsdiv"
 
 
+class UDivCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import UDivFold
+
+        return (UDivFold(),)
+
+
 @irdl_op_definition
 class UDivOp(BinaryBVOp, SimpleSMTLibOp):
     name = "smt.bv.udiv"
+
+    traits = traits_def(traits.Pure(), UDivCanonicalizationPatterns())
 
     def op_name(self) -> str:
         return "bvudiv"

--- a/xdsl_smt/passes/canonicalization_patterns/smt_bv.py
+++ b/xdsl_smt/passes/canonicalization_patterns/smt_bv.py
@@ -27,6 +27,16 @@ def unsigned_to_signed(value: int, width: int) -> int:
     return value - (1 << width) if value >= (1 << (width - 1)) else value
 
 
+def get_min_signed_value(width: int) -> int:
+    "Return the minimum signed integer value for a given width as an unsigned int"
+    return 1 << (width - 1)
+
+
+def get_all_ones(width: int) -> int:
+    "Return the unsigned int representation of a bitvector of 1's at a given width."
+    return (1 << width) - 1
+
+
 def bv_folding_canonicalization_pattern(
     op_type: type[Operation], operator: Callable[[Sequence[int]], int]
 ) -> type[RewritePattern]:
@@ -78,6 +88,32 @@ XorCanonicalizationPattern = bv_folding_canonicalization_pattern(
 )
 
 
+class UDivFold(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: smt_bv.UDivOp, rewriter: PatternRewriter):
+        # Get the result width
+        assert isinstance(type := op.results[0].type, smt_bv.BitVectorType)
+        width = type.width.data
+
+        # Check if rhs is constant
+        rhs = get_bv_constant(op.rhs)
+        if rhs is None:
+            return
+
+        # Division by zero returns a bv of all ones
+        if rhs == 0:
+            all_ones_bv = get_all_ones(width)
+            rewriter.replace_matched_op(smt_bv.ConstantOp(all_ones_bv, type.width))
+            return
+
+        # Check if lhs is constant
+        lhs = get_bv_constant(op.lhs)
+        if lhs is None:
+            return
+
+        rewriter.replace_matched_op(smt_bv.ConstantOp(lhs // rhs, type.width))
+
+
 class SDivFold(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: smt_bv.SDivOp, rewriter: PatternRewriter):
@@ -94,9 +130,22 @@ class SDivFold(RewritePattern):
         lhs = unsigned_to_signed(lhs, width)
         rhs = unsigned_to_signed(rhs, width)
 
-        # Division by zero or overflow
-        if rhs == 0 or (lhs == -(2 ** (width - 1)) and rhs == -1):
-            rewriter.replace_matched_op(smt_bv.ConstantOp(0, type.width))
+        # Division by zero returns:
+        #   all ones if lhs is positve
+        #   one if lhs is negative
+        if rhs == 0:
+            if lhs >= 0:
+                all_ones_bv = get_all_ones(width)
+                rewriter.replace_matched_op(smt_bv.ConstantOp(all_ones_bv, type.width))
+                return
+            else:
+                rewriter.replace_matched_op(smt_bv.ConstantOp(1, type.width))
+                return
+
+        # An underflowing signed division should return the signed min value
+        if lhs == -(2 ** (width - 1)) and rhs == -1:
+            signed_min_val = get_min_signed_value(width)
+            rewriter.replace_matched_op(smt_bv.ConstantOp(signed_min_val, type.width))
             return
 
         value = lhs // rhs if lhs * rhs > 0 else (lhs + (-lhs % rhs)) // rhs
@@ -104,33 +153,57 @@ class SDivFold(RewritePattern):
         rewriter.replace_matched_op(smt_bv.ConstantOp(value, type.width))
 
 
+class URemFold(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: smt_bv.URemOp, rewriter: PatternRewriter):
+        # return
+        # Check if rhs is constant
+        rhs = get_bv_constant(op.rhs)
+        if rhs is None:
+            return
+
+        # A remainder by zero should return the lhs value
+        if rhs == 0 and isinstance(op.lhs, OpResult):
+            rewriter.replace_matched_op(op.lhs.op.clone())
+            return
+
+        # Check if lhs is constant
+        lhs = get_bv_constant(op.lhs)
+        if lhs is None:
+            return
+
+        assert isinstance(type := op.results[0].type, smt_bv.BitVectorType)
+
+        rewriter.replace_matched_op(smt_bv.ConstantOp(lhs % rhs, type.width))
+
+
 class SRemFold(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: smt_bv.SRemOp, rewriter: PatternRewriter):
-        # Check if all operands are constants
-        lhs = get_bv_constant(op.lhs)
-        rhs = get_bv_constant(op.rhs)
-        if lhs is None or rhs is None:
-            return
-
         # Get the result width
         assert isinstance(type := op.results[0].type, smt_bv.BitVectorType)
         width = type.width.data
 
-        lhs = unsigned_to_signed(lhs, width)
-        rhs = unsigned_to_signed(rhs, width)
-
-        # Remainder by zero or overflow
-        if rhs == 0 or (lhs == -(2 ** (width - 1)) and rhs == -1):
-            rewriter.replace_matched_op(smt_bv.ConstantOp(0, type.width))
+        # Check if rhs is constant
+        rhs = get_bv_constant(op.rhs)
+        if rhs is None:
             return
 
-        if lhs < 0 and rhs > 0 or lhs > 0 and rhs < 0:
-            value = (lhs % rhs) - rhs
-        else:
-            value = lhs % rhs
+        rhs = unsigned_to_signed(rhs, width)
 
-        value = wrap_value(value, width)
+        # A remainder by zero should return the lhs value
+        if rhs == 0 and isinstance(op.lhs, OpResult):
+            rewriter.replace_matched_op(op.lhs.op.clone())
+            return
+
+        # Check if lhs is constant
+        lhs = get_bv_constant(op.lhs)
+        if lhs is None:
+            return
+
+        lhs = unsigned_to_signed(lhs, width)
+
+        value = wrap_value(lhs % rhs, width)
         rewriter.replace_matched_op(smt_bv.ConstantOp(value, type.width))
 
 

--- a/xdsl_smt/utils/lower_utils.py
+++ b/xdsl_smt/utils/lower_utils.py
@@ -379,7 +379,7 @@ def lowerToClassMethod(
     expr += ")"
 
     if type(op) in op_to_cons:
-        conds, actions = zip(*op_to_cons[type(op)]) # type: ignore
+        conds, actions = zip(*op_to_cons[type(op)])  # type: ignore
 
         og_op_names = get_op_names(op)
         conds: list[str] = [cond.format(*og_op_names) for cond in conds]

--- a/xdsl_smt/utils/lower_utils.py
+++ b/xdsl_smt/utils/lower_utils.py
@@ -379,10 +379,9 @@ def lowerToClassMethod(
     expr += ")"
 
     if type(op) in op_to_cons:
+        conds, actions = zip(*op_to_cons[type(op)]) # type: ignore
+
         og_op_names = get_op_names(op)
-
-        conds, actions = zip(*op_to_cons[type(op)])
-
         conds: list[str] = [cond.format(*og_op_names) for cond in conds]
         actions: list[str] = [act.format(ret_val, *og_op_names) for act in actions]
 

--- a/xdsl_smt/utils/synthesizer_utils/solution_set.py
+++ b/xdsl_smt/utils/synthesizer_utils/solution_set.py
@@ -38,7 +38,7 @@ def verify_function(
     if func.cond is not None:
         cur_helper.append(func.cond)
     return verify_transfer_function(
-        func.get_function(), concrete_op, cur_helper + helper_funcs, ctx, 32
+        func.get_function(), concrete_op, cur_helper + helper_funcs, ctx, 1, 32
     )
 
 
@@ -198,7 +198,7 @@ class SolutionSet(ABC):
             if sol.cond is not None:
                 cur_helper.append(sol.cond)
             if not verify_transfer_function(
-                sol.get_function(), concrete_op, cur_helper + helper_funcs, ctx, 16
+                sol.get_function(), concrete_op, cur_helper + helper_funcs, ctx, 1, 16
             ):
                 unsound_lst.append(i)
         for unsound_idx in unsound_lst[::-1]:

--- a/xdsl_smt/utils/synthesizer_utils/verifier_utils.py
+++ b/xdsl_smt/utils/synthesizer_utils/verifier_utils.py
@@ -62,10 +62,6 @@ from xdsl_smt.semantics.transfer_semantics import (
 from xdsl_smt.semantics.comb_semantics import comb_semantics
 
 
-def solve_vector_width(maximal_bits: int):
-    return list(range(1, maximal_bits + 1))
-
-
 def verify_pattern(ctx: Context, op: ModuleOp) -> bool:
     cloned_op = op.clone()
     stream = StringIO()
@@ -337,9 +333,7 @@ def build_init_module(
 
         if func_name == transfer_function_name:
             assert transfer_function_obj is None
-            transfer_function_obj = TransferFunction(
-                func,
-            )
+            transfer_function_obj = TransferFunction(func)
         if func_name == DOMAIN_CONSTRAINT:
             assert domain_constraint is None
             domain_constraint = FunctionCollection(func, create_smt_function, ctx)
@@ -379,7 +373,8 @@ def verify_transfer_function(
     concrete_func: FuncOp,
     helper_funcs: list[FuncOp],
     ctx: Context,
-    maximal_verify_bits: int = 32,
+    min_verify_bits: int,
+    max_verify_bits: int,
 ) -> int:
     is_custom_concrete_func = check_custom_concrete_func(concrete_func)
     (
@@ -393,7 +388,8 @@ def verify_transfer_function(
     )
 
     FunctionCallInline(False, func_name_to_func).apply(ctx, module_op)
-    for width in solve_vector_width(maximal_verify_bits):
+
+    for width in range(min_verify_bits, max_verify_bits + 1):
         smt_module = module_op.clone()
 
         # expand for loops


### PR DESCRIPTION
There are few bugs in SRemFold and SDivFold.
When the canonicalizer sees constants as operands for the SRem and SDiv operations, it tries to elide the instruction and instead just return the new constant itself, unfortunatly on the edge cases it doesn't actually match z3's semantics.

For SRem when the rhs is 0 then the result should always be the lhs.
For SDiv when there's an underflow it should return INT_MIN, and when there's a div by zero the result should either be one or neg one, depending on sign of lhs
