### PR TITLE
Small Adjustment in Eval Engine

### DIFF
--- a/tests/synth/Operations/SubNswNuw.mlir
+++ b/tests/synth/Operations/SubNswNuw.mlir
@@ -1,7 +1,7 @@
 "builtin.module"() ({
   "func.func"() ({
   ^bb0(%arg0: !transfer.integer, %arg1: !transfer.integer):
-    %nsw = "transfer.cmp"(%arg0, %arg1) {predicate=9:i64}: (!transfer.integer, !transfer.integer) -> i1
+    %nuw = "transfer.cmp"(%arg0, %arg1) {predicate=9:i64}: (!transfer.integer, !transfer.integer) -> i1
 
     %res = "transfer.sub"(%arg0, %arg1) : (!transfer.integer, !transfer.integer) -> !transfer.integer
     %xor0 = "transfer.xor"(%arg0, %res) : (!transfer.integer, !transfer.integer) -> !transfer.integer

--- a/xdsl_smt/cli/eval_final.py
+++ b/xdsl_smt/cli/eval_final.py
@@ -121,9 +121,9 @@ def _get_dist_table(
     s = ""
     use_llvm = sum(x.exacts for x in llvm.per_bit_res) != 0
 
-    s += "           ######  Dists  ######           \n"
-    s += "bw  | Top     | Synth   | LLVM    | Meet   \n"
-    s += "----|---------|---------|---------|--------\n"
+    s += "           ######  Dists  ######                     \n"
+    s += "bw  | Cases   | Top     | Synth   | LLVM    | Meet   \n"
+    s += "----|---------|---------|---------|---------|--------\n"
     for t_pb, s_pb, l_pb, m_pb in zip(
         top.per_bit_res, synth.per_bit_res, llvm.per_bit_res, meet.per_bit_res
     ):
@@ -132,7 +132,7 @@ def _get_dist_table(
         bw = f"{t_pb.bitwidth}" + a + p
         llvm_dist = l_pb.dist if use_llvm else "N/A"
         meet_dist = m_pb.dist if use_llvm else "N/A"
-        s += f"{bw:<4}| {t_pb.dist:<7} | {s_pb.dist:<7} | {llvm_dist:<7} | {meet_dist:<7}\n"
+        s += f"{bw:<4}| {t_pb.all_cases:<7} | {t_pb.dist:<7} | {s_pb.dist:<7} | {llvm_dist:<7} | {meet_dist:<7}\n"
 
     return s
 

--- a/xdsl_smt/cli/eval_final.py
+++ b/xdsl_smt/cli/eval_final.py
@@ -198,6 +198,8 @@ def main() -> None:
 
         inputs.append((args, domain, input_path, solution_path, op))
 
+    inputs = sorted(inputs, key=lambda x: (x[1].value, x[4]))
+
     with Pool() as p:
         data = p.map(run_wrapper, inputs)
 

--- a/xdsl_smt/eval_engine/src/AbstVal.h
+++ b/xdsl_smt/eval_engine/src/AbstVal.h
@@ -253,7 +253,7 @@ public:
     return ret;
   }
 
-  static double maxDist(unsigned int bw) { return 2 * bw; }
+  static double maxDist(unsigned int bw) { return bw; }
 };
 
 class UConstRange : public AbstVal<UConstRange, 2> {
@@ -325,14 +325,14 @@ public:
       return 0;
 
     if (isBottom())
-      return A::APIntOps::abdu(rhs.lower(), rhs.upper()).getZExtValue();
+      return A::APIntOps::abdu(rhs.lower(), rhs.upper()).getActiveBits();
 
     if (rhs.isBottom())
-      return A::APIntOps::abdu(lower(), upper()).getZExtValue();
+      return A::APIntOps::abdu(lower(), upper()).getActiveBits();
 
-    unsigned long ld = A::APIntOps::abdu(lower(), rhs.lower()).getZExtValue();
-    unsigned long ud = A::APIntOps::abdu(upper(), rhs.upper()).getZExtValue();
-    return static_cast<unsigned int>(ld + ud);
+    A::APInt ld = A::APIntOps::abdu(lower(), rhs.lower());
+    A::APInt ud = A::APIntOps::abdu(upper(), rhs.upper());
+    return static_cast<unsigned long>((ld + ud).getActiveBits());
   }
 
   static const UConstRange rand(std::mt19937 &rng, unsigned int bw) {
@@ -385,12 +385,7 @@ public:
     return ret;
   }
 
-  static double maxDist(unsigned int bw) {
-    if (bw == 1)
-      return 2;
-    return static_cast<double>(A::APInt::getMaxValue(bw).getZExtValue() - 1) *
-           2;
-  }
+  static double maxDist(unsigned int bw) { return static_cast<double>(bw); }
 };
 
 class SConstRange : public AbstVal<SConstRange, 2> {
@@ -462,14 +457,14 @@ public:
       return 0;
 
     if (isBottom())
-      return A::APIntOps::abds(rhs.lower(), rhs.upper()).getZExtValue();
+      return A::APIntOps::abds(rhs.lower(), rhs.upper()).getActiveBits();
 
     if (rhs.isBottom())
-      return A::APIntOps::abds(lower(), upper()).getZExtValue();
+      return A::APIntOps::abds(lower(), upper()).getActiveBits();
 
-    unsigned long ld = A::APIntOps::abds(lower(), rhs.lower()).getZExtValue();
-    unsigned long ud = A::APIntOps::abds(upper(), rhs.upper()).getZExtValue();
-    return static_cast<unsigned int>(ld + ud);
+    A::APInt ld = A::APIntOps::abds(lower(), rhs.lower());
+    A::APInt ud = A::APIntOps::abds(upper(), rhs.upper());
+    return static_cast<unsigned long>((ld + ud).getActiveBits());
   }
 
   static const SConstRange rand(std::mt19937 &rng, unsigned int bw) {
@@ -522,12 +517,7 @@ public:
     return ret;
   }
 
-  static double maxDist(unsigned int bw) {
-    if (bw == 1)
-      return 2;
-    return static_cast<double>(A::APInt::getMaxValue(bw).getZExtValue() - 1) *
-           2;
-  }
+  static double maxDist(unsigned int bw) { return static_cast<double>(bw); }
 };
 
 template <unsigned int N>

--- a/xdsl_smt/eval_engine/src/Eval.h
+++ b/xdsl_smt/eval_engine/src/Eval.h
@@ -149,6 +149,15 @@ public:
       for (unsigned int j = 0; j < toEval[i].size(); ++j) {
         auto [lhs, rhs, best] = toEval[i][j];
 
+        // Xuanyu added this check. Ideally, the value of the best transformer
+        // would not be bottom, if at least one "valid" concrete value that
+        // satisfys op_constraint have been sampled. However, there is not a
+        // general way to determine whether an abstract input contains such a
+        // valid concrete value, so we do the skip here. In practice, this issue
+        // only happens when concrete_op is shifting operators.
+        if (best.isBottom())
+          continue;
+
         bool topExact = top == best;
         unsigned long topDis = top.distance(best);
 

--- a/xdsl_smt/eval_engine/src/Results.h
+++ b/xdsl_smt/eval_engine/src/Results.h
@@ -75,7 +75,8 @@ public:
     os << std::left << std::setw(20) << "num unsolved:" << unsolvedCases
        << "\n";
     os << std::left << std::setw(20)
-       << "base distance:" << baseDistance / maxDist(bw) << "\n";
+       << "base distance:" << static_cast<double>(baseDistance) / maxDist(bw)
+       << "\n";
     printMember(
         os, "num sound:", [](const Result &x) { return x.sound; },
         std::nullopt);

--- a/xdsl_smt/eval_engine/src/jit.h
+++ b/xdsl_smt/eval_engine/src/jit.h
@@ -105,7 +105,8 @@ public:
     return llvm::cantFail(jit->lookup(fnName)).toPtr<T>();
   }
 
-  template <typename T> std::vector<T> getFns(const std::vector<std::string> &v) {
+  template <typename T>
+  std::vector<T> getFns(const std::vector<std::string> &v) {
     std::vector<T> fns;
     std::transform(v.begin(), v.end(), std::back_inserter(fns),
                    [this](const std::string &x) { return getFn<T>(x); });

--- a/xdsl_smt/eval_engine/src/llvm_tests.h
+++ b/xdsl_smt/eval_engine/src/llvm_tests.h
@@ -24,7 +24,7 @@ inline llvm::ConstantRange make_llvm_ucr(const UConstRange &x) {
 
 inline const UConstRange
 ucr_xfer_wrapper(const UConstRange &lhs, const UConstRange &rhs,
-                const XferFn<llvm::ConstantRange> &fn) {
+                 const XferFn<llvm::ConstantRange> &fn) {
   llvm::ConstantRange x = fn(make_llvm_ucr(lhs), make_llvm_ucr(rhs));
 
   if (x.isWrappedSet())
@@ -38,7 +38,7 @@ ucr_xfer_wrapper(const UConstRange &lhs, const UConstRange &rhs,
                       A::APInt(lhs.bw(), x.getUpper().getZExtValue()) - 1});
 }
 
-#define UCR_OP(e)                                                               \
+#define UCR_OP(e)                                                              \
   [](const llvm::ConstantRange &l, const llvm::ConstantRange &r) { return e; }
 
 const std::vector<


### PR DESCRIPTION
This PR mainly includes:
1. Adjusted the distance function of CR to make it grow linearly as the bitwidth increases
2. As we only call `dis(a,b)` when a and b are comparable in the synthesis algorithm, we changed the maxDist of KB&CR to be the max distance among the cases such that a and b are comparable.
3. skip best == Bottom in EvalFinal